### PR TITLE
Target the comparator population by size, not by precision

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -56,6 +56,19 @@
   stops with a validation error naming the argument it actually received. Call
   `mlumr()` with named arguments.
 
+* **Continuous multi-row comparator estimand, and `outcome_n` is now required
+  for it.** For the normal family the comparator-population standardized effect
+  from several `set_agd()` rows is weighted by `outcome_n` (sample size) rather
+  than by inverse variance, so splitting one comparator population into subgroup
+  rows no longer changes the estimand. An inverse-variance average estimates a
+  common mean efficiently but is not the comparator population's mean, which is
+  the size-weighted mixture of its strata. Because there is no defensible way to
+  combine several population strata without knowing how large they are,
+  `set_agd()` now requires `outcome_n` when normal aggregate data have more than
+  one row and errors rather than silently falling back to precision weights.
+  `naive()` and `stc()` use the same weighting. Single-row AgD is unchanged and
+  still does not require `outcome_n`.
+
 * **`naive()` combines multiple aggregate rows as strata.** For binomial data
   the comparator standard error was computed as though the pooled comparator
   were a single binomial sample of size `sum(n)`. It is now the variance of the

--- a/R/data_setup.R
+++ b/R/data_setup.R
@@ -575,6 +575,10 @@ set_agd <- function(data, treatment,
     .validate_agd_binomial_outcomes(data[[outcome_r]], data[[outcome_n]])
   } else if (family == "normal") {
     .validate_agd_normal_outcomes(data[[outcome_mean]], data[[outcome_se]])
+    if (nrow(data) > 1L && is.null(outcome_n)) {
+      stop("`outcome_n` is required for multiple normal aggregate rows so ",
+           "they can be combined using population weights.", call. = FALSE)
+    }
     if (!is.null(outcome_n)) {
       .validate_agd_sample_size(data[[outcome_n]])
     }

--- a/R/data_setup.R
+++ b/R/data_setup.R
@@ -326,8 +326,11 @@ set_ipd <- function(data, treatment, outcome, covariates,
 #' @param data Data frame containing AgD summary statistics
 #' @param treatment Column name for treatment variable
 #' @param family Outcome family: `"binomial"`, `"normal"`, or `"poisson"`
-#' @param outcome_n Column name for sample size (required for binomial,
-#'   optional for normal)
+#' @param outcome_n Column name for sample size. Required for binomial. For
+#'   normal, required when there is more than one aggregate row, because the
+#'   comparator-population estimand is the size-weighted mixture of those rows
+#'   and they cannot be combined without knowing how large each is; optional for
+#'   a single row, where the weighting is irrelevant.
 #' @param outcome_r Column name for number of events (required for binomial
 #'   and poisson)
 #' @param outcome_mean Column name for mean outcome (required for normal)

--- a/R/family_config.R
+++ b/R/family_config.R
@@ -55,7 +55,7 @@ family_config <- list(
     marginal_effect_vars = list(
       md = c("delta_index", "delta_comparator")
     ),
-    comp_weight_field    = NULL
+    comp_weight_field    = "agd_weight"
   ),
   poisson = list(
     stan_prefix          = "mlumr_poisson",

--- a/R/mlumr.R
+++ b/R/mlumr.R
@@ -42,21 +42,22 @@
 #' geometric. Passing log-scale summaries silently misspecifies the
 #' likelihood. See [set_agd()] for details.
 #'
-#' **Comparator-population weighting is family-dependent.** Integrated
-#' marginal predictions in the comparator population (`*_comparator`
-#' generated quantities) are weighted by:
+#' **The comparator population is the size-weighted mixture of its aggregate
+#' rows.** Integrated marginal predictions in the comparator population
+#' (`*_comparator` generated quantities) weight each row by the population it
+#' represents:
 #' \itemize{
-#'   \item **binomial**: `n_agd[k]` (AgD sample size), so larger
-#'     AgD rows contribute more to the marginal mean.
-#'   \item **normal**: equal weights across AgD rows (`/ n_agd_rows`),
-#'     reflecting the normal likelihood's treatment of each row as a
-#'     single summary statistic.
-#'   \item **poisson**: `E_agd[k]` (AgD exposure), matching the
-#'     rate-based likelihood.
+#'   \item **binomial**: `n_agd[k]`, the AgD sample size.
+#'   \item **normal**: `agd_weight[k]`, from `outcome_n`. This is required for
+#'     more than one aggregate row, and is `1` for a single row where the
+#'     weighting is irrelevant.
+#'   \item **poisson**: `E_agd[k]`, the AgD exposure.
 #' }
-#' Each weighting is natural for the corresponding likelihood; users
-#' comparing marginal effects across families should be aware they are
-#' not identically weighted.
+#' The weights say which population the estimand refers to, and are deliberately
+#' separate from the likelihood's own precision weighting, which says how much
+#' each row constrains the parameters. Because the parts of a split subgroup sum
+#' to the whole, the estimand does not change with how the aggregate evidence
+#' happens to be tabulated.
 #'
 #' **Weakly-identified coefficients in the relaxed model** —
 #' `beta_comparator` is identified only through AgD, so the relaxed

--- a/R/mlumr.R
+++ b/R/mlumr.R
@@ -357,6 +357,18 @@ mlumr <- function(data,
     stan_data$y_ipd <- as.numeric(ipd_data$.outcome)
     stan_data$y_agd <- array(as.numeric(agd_data$.y))
     stan_data$se_agd <- array(as.numeric(agd_data$.se))
+    # Target-population weights for the comparator estimand. These say which
+    # comparator population the standardized effect refers to, and are separate
+    # from the likelihood's 1/se^2 precision weights. set_agd() requires
+    # outcome_n for more than one row, so the fallback covers single-row data.
+    n_agd_rows <- length(stan_data$y_agd)
+    agd_n <- agd_data$.n
+    stan_data$agd_weight <- if (!is.null(agd_n) &&
+                                  all(is.finite(agd_n)) && all(agd_n > 0)) {
+      as.array(as.numeric(agd_n))
+    } else {
+      as.array(rep(1, n_agd_rows))
+    }
     stan_data$prior_sigma_location <- sigma_fields$mean
     stan_data$prior_sigma_scale <- sigma_fields$sd
     stan_data$prior_sigma_dist <- sigma_fields$dist

--- a/R/naive.R
+++ b/R/naive.R
@@ -136,9 +136,15 @@ naive <- function(data, link = NULL, conf_level = 0.95) {
   n_index <- nrow(ipd)
   var_index <- var(ipd$.outcome) / n_index
 
-  iv_weights <- 1 / (agd$.se^2)
-  mean_comparator <- weighted.mean(agd$.y, iv_weights)
-  var_comparator <- 1 / sum(iv_weights)
+  # Sample-size weights, not inverse-variance weights. An inverse-variance
+  # average estimates a common mean efficiently, but the estimand here is the
+  # comparator population's mean, which is the size-weighted mixture of its
+  # strata. This matches what the Stan models and stc() target. Both reduce to
+  # the same value for single-row aggregate data.
+  row_w <- if (!is.null(agd$.n)) .normalize_weights(agd$.n) else
+    rep(1 / nrow(agd), nrow(agd))
+  mean_comparator <- sum(row_w * agd$.y)
+  var_comparator <- sum(row_w^2 * agd$.se^2)
 
   estimate <- mean_index - mean_comparator
   se <- sqrt(var_index + var_comparator)

--- a/R/stc.R
+++ b/R/stc.R
@@ -259,14 +259,22 @@ stc <- function(data, link = NULL, conf_level = 0.95) {
 #' @keywords internal
 .stc_normal <- function(data, fit, ipd, agd, newdata, link_resolved,
                         conf_level, z, beta_hat, V, n_int) {
+  if (nrow(agd) > 1L && is.null(agd$.n)) {
+    stop("`outcome_n` is required for multiple normal AgD rows.", call. = FALSE)
+  }
+  # Population weights, not precision weights. The estimand is the comparator
+  # population's mean, which is the size-weighted mixture of its strata; an
+  # inverse-variance average estimates a common mean instead and is a different
+  # quantity when the strata differ.
+  agd_weights <- agd$.n %||% 1
   pred_y <- predict(fit, newdata = newdata, type = "response")
   weights <- if (data$has_integration) {
-    rep(1 / agd$.se^2, each = n_int)
+    rep(agd_weights, each = n_int)
   } else {
-    1 / (agd$.se^2)
+    agd_weights
   }
   y_hat_A <- weighted.mean(pred_y, weights)
-  y_B <- weighted.mean(agd$.y, 1 / agd$.se^2)
+  y_B <- sum(.normalize_weights(agd_weights) * agd$.y)
   estimate <- y_hat_A - y_B
 
   X_comp_design <- .stc_model_matrix(fit, newdata)
@@ -280,7 +288,7 @@ stc <- function(data, link = NULL, conf_level = 0.95) {
 
   var_A <- .nonnegative_variance(as.numeric(t(grad) %*% V %*% grad),
                                  "normal STC index variance")
-  var_B <- 1 / sum(1 / agd$.se^2)
+  var_B <- sum(.normalize_weights(agd_weights)^2 * agd$.se^2)
   se <- .sqrt_variance(var_A + var_B, "normal STC contrast variance")
 
   list(

--- a/inst/stan/mlumr_normal_relaxed.stan
+++ b/inst/stan/mlumr_normal_relaxed.stan
@@ -23,6 +23,11 @@ data {
   // set_agd() rejects a non-positive standard error, so the normal density
   // below never sees a zero scale.
   array[n_agd_rows] real<lower=0> se_agd;
+  // Target-population weights for the comparator estimand (sample-size weights
+  // when outcome_n is supplied, else all 1 = equal per-row). Separate from the
+  // likelihood's precision weighting; defines which comparator population the
+  // standardized effect targets.
+  vector<lower=0>[n_agd_rows] agd_weight;
 
   // Integration points for AgD
   int<lower=1> n_int;
@@ -148,10 +153,12 @@ generated quantities {
     }
   }
 
-  // Marginal predictions in comparator population, equal weights.
-  // Equal weighting avoids double-counting with the likelihood (which already
-  // upweights lower-SE studies through the normal density). For single-row
-  // AgD (the most common case), weighting is irrelevant.
+  // Marginal predictions in the comparator population, weighted by `agd_weight`.
+  // The comparator target population is the size-weighted mixture of its AgD
+  // subgroups (sample-size weights for multiple rows; one for a single row), so
+  // splitting one population into two rows does not change the estimand. This
+  // target weighting is deliberately separate from the likelihood's precision
+  // (1/se^2) weighting. For single-row AgD the weight is irrelevant.
   {
     vector[n_agd_rows] row_index;
     vector[n_agd_rows] row_comparator;
@@ -160,7 +167,7 @@ generated quantities {
     for (k in 1:n_agd_rows) {
       vector[n_int] y_idx_k = mu_index + X_int[k] * beta_index;
       vector[n_int] y_cmp_k = mu_comparator + X_int[k] * beta_comparator;
-      weights[k] = 1;
+      weights[k] = agd_weight[k];
 
       if (link == 1) {
         row_index[k] = mean(y_idx_k);

--- a/inst/stan/mlumr_normal_spfa.stan
+++ b/inst/stan/mlumr_normal_spfa.stan
@@ -23,6 +23,11 @@ data {
   // set_agd() rejects a non-positive standard error, so the normal density
   // below never sees a zero scale.
   array[n_agd_rows] real<lower=0> se_agd;
+  // Target-population weights for the comparator estimand (sample-size weights
+  // when outcome_n is supplied, else all 1 = equal per-row). Separate from the
+  // likelihood's precision weighting; defines which comparator population the
+  // standardized effect targets.
+  vector<lower=0>[n_agd_rows] agd_weight;
 
   // Integration points for AgD
   int<lower=1> n_int;
@@ -138,10 +143,12 @@ generated quantities {
     }
   }
 
-  // Marginal predictions in comparator population, equal weights.
-  // Equal weighting avoids double-counting with the likelihood (which already
-  // upweights lower-SE studies through the normal density). For single-row
-  // AgD (the most common case), weighting is irrelevant.
+  // Marginal predictions in the comparator population, weighted by `agd_weight`.
+  // The comparator target population is the size-weighted mixture of its AgD
+  // subgroups (sample-size weights for multiple rows; one for a single row), so
+  // splitting one population into two rows does not change the estimand. This
+  // target weighting is deliberately separate from the likelihood's precision
+  // (1/se^2) weighting. For single-row AgD the weight is irrelevant.
   {
     vector[n_agd_rows] row_index;
     vector[n_agd_rows] row_comparator;
@@ -150,7 +157,7 @@ generated quantities {
     for (k in 1:n_agd_rows) {
       vector[n_int] y_idx_k = mu_index + X_int[k] * beta;
       vector[n_int] y_cmp_k = mu_comparator + X_int[k] * beta;
-      weights[k] = 1;
+      weights[k] = agd_weight[k];
 
       if (link == 1) {
         row_index[k] = mean(y_idx_k);

--- a/man/mlumr.Rd
+++ b/man/mlumr.Rd
@@ -119,21 +119,22 @@ cases \code{set_agd()} expects \code{outcome_mean} and \code{outcome_se} on the
 geometric. Passing log-scale summaries silently misspecifies the
 likelihood. See \code{\link[=set_agd]{set_agd()}} for details.
 
-\strong{Comparator-population weighting is family-dependent.} Integrated
-marginal predictions in the comparator population (\verb{*_comparator}
-generated quantities) are weighted by:
+\strong{The comparator population is the size-weighted mixture of its aggregate
+rows.} Integrated marginal predictions in the comparator population
+(\verb{*_comparator} generated quantities) weight each row by the population it
+represents:
 \itemize{
-\item \strong{binomial}: \code{n_agd[k]} (AgD sample size), so larger
-AgD rows contribute more to the marginal mean.
-\item \strong{normal}: equal weights across AgD rows (\verb{/ n_agd_rows}),
-reflecting the normal likelihood's treatment of each row as a
-single summary statistic.
-\item \strong{poisson}: \code{E_agd[k]} (AgD exposure), matching the
-rate-based likelihood.
+\item \strong{binomial}: \code{n_agd[k]}, the AgD sample size.
+\item \strong{normal}: \code{agd_weight[k]}, from \code{outcome_n}. This is required for
+more than one aggregate row, and is \code{1} for a single row where the
+weighting is irrelevant.
+\item \strong{poisson}: \code{E_agd[k]}, the AgD exposure.
 }
-Each weighting is natural for the corresponding likelihood; users
-comparing marginal effects across families should be aware they are
-not identically weighted.
+The weights say which population the estimand refers to, and are deliberately
+separate from the likelihood's own precision weighting, which says how much
+each row constrains the parameters. Because the parts of a split subgroup sum
+to the whole, the estimand does not change with how the aggregate evidence
+happens to be tabulated.
 
 \strong{Weakly-identified coefficients in the relaxed model} —
 \code{beta_comparator} is identified only through AgD, so the relaxed

--- a/man/set_agd.Rd
+++ b/man/set_agd.Rd
@@ -26,8 +26,11 @@ set_agd(
 
 \item{family}{Outcome family: \code{"binomial"}, \code{"normal"}, or \code{"poisson"}}
 
-\item{outcome_n}{Column name for sample size (required for binomial,
-optional for normal)}
+\item{outcome_n}{Column name for sample size. Required for binomial. For
+normal, required when there is more than one aggregate row, because the
+comparator-population estimand is the size-weighted mixture of those rows
+and they cannot be combined without knowing how large each is; optional for
+a single row, where the weighting is irrelevant.}
 
 \item{outcome_r}{Column name for number of events (required for binomial
 and poisson)}

--- a/src/stanExports_mlumr_normal_relaxed.h
+++ b/src/stanExports_mlumr_normal_relaxed.h
@@ -13,129 +13,129 @@ namespace model_mlumr_normal_relaxed_namespace {
 using stan::model::model_base_crtp;
 using namespace stan::math;
 stan::math::profile_map profiles__;
-static constexpr std::array<const char*, 202> locations_array__ =
+static constexpr std::array<const char*, 204> locations_array__ =
   {" (found before start of program)",
-  " (in 'mlumr_normal_relaxed', line 137, column 2 to column 24)",
-  " (in 'mlumr_normal_relaxed', line 141, column 2 to column 22)",
-  " (in 'mlumr_normal_relaxed', line 145, column 2 to column 60)",
-  " (in 'mlumr_normal_relaxed', line 146, column 2 to column 29)",
-  " (in 'mlumr_normal_relaxed', line 147, column 2 to column 34)",
-  " (in 'mlumr_normal_relaxed', line 148, column 2 to column 56)",
-  " (in 'mlumr_normal_relaxed', line 149, column 2 to column 69)",
-  " (in 'mlumr_normal_relaxed', line 151, column 2 to column 48)",
-  " (in 'mlumr_normal_relaxed', line 192, column 2 to column 19)",
-  " (in 'mlumr_normal_relaxed', line 193, column 2 to column 24)",
-  " (in 'mlumr_normal_relaxed', line 195, column 2 to column 21)",
-  " (in 'mlumr_normal_relaxed', line 196, column 2 to column 26)",
-  " (in 'mlumr_normal_relaxed', line 197, column 2 to column 26)",
-  " (in 'mlumr_normal_relaxed', line 198, column 2 to column 31)",
-  " (in 'mlumr_normal_relaxed', line 199, column 2 to column 26)",
-  " (in 'mlumr_normal_relaxed', line 200, column 2 to column 31)",
-  " (in 'mlumr_normal_relaxed', line 201, column 2 to column 31)",
-  " (in 'mlumr_normal_relaxed', line 202, column 2 to column 36)",
-  " (in 'mlumr_normal_relaxed', line 204, column 2 to column 27)",
-  " (in 'mlumr_normal_relaxed', line 207, column 2 to column 28)",
-  " (in 'mlumr_normal_relaxed', line 208, column 2 to column 33)",
-  " (in 'mlumr_normal_relaxed', line 211, column 11 to column 16)",
-  " (in 'mlumr_normal_relaxed', line 211, column 4 to column 62)",
-  " (in 'mlumr_normal_relaxed', line 212, column 11 to column 16)",
-  " (in 'mlumr_normal_relaxed', line 212, column 4 to column 77)",
-  " (in 'mlumr_normal_relaxed', line 220, column 6 to column 55)",
-  " (in 'mlumr_normal_relaxed', line 221, column 6 to column 65)",
-  " (in 'mlumr_normal_relaxed', line 222, column 6 to column 39)",
-  " (in 'mlumr_normal_relaxed', line 223, column 6 to column 49)",
-  " (in 'mlumr_normal_relaxed', line 224, column 6 to column 39)",
-  " (in 'mlumr_normal_relaxed', line 225, column 6 to column 49)",
-  " (in 'mlumr_normal_relaxed', line 226, column 6 to column 66)",
-  " (in 'mlumr_normal_relaxed', line 219, column 11 to line 227, column 5)",
-  " (in 'mlumr_normal_relaxed', line 214, column 6 to column 40)",
-  " (in 'mlumr_normal_relaxed', line 215, column 6 to column 50)",
-  " (in 'mlumr_normal_relaxed', line 216, column 6 to column 41)",
-  " (in 'mlumr_normal_relaxed', line 217, column 6 to column 51)",
-  " (in 'mlumr_normal_relaxed', line 218, column 6 to column 55)",
-  " (in 'mlumr_normal_relaxed', line 213, column 19 to line 219, column 5)",
-  " (in 'mlumr_normal_relaxed', line 213, column 4 to line 227, column 5)",
-  " (in 'mlumr_normal_relaxed', line 210, column 2 to line 228, column 3)",
-  " (in 'mlumr_normal_relaxed', line 234, column 11 to column 21)",
-  " (in 'mlumr_normal_relaxed', line 234, column 4 to column 33)",
-  " (in 'mlumr_normal_relaxed', line 235, column 11 to column 21)",
-  " (in 'mlumr_normal_relaxed', line 235, column 4 to column 38)",
-  " (in 'mlumr_normal_relaxed', line 236, column 11 to column 21)",
-  " (in 'mlumr_normal_relaxed', line 236, column 4 to column 31)",
-  " (in 'mlumr_normal_relaxed', line 238, column 13 to column 18)",
-  " (in 'mlumr_normal_relaxed', line 238, column 6 to column 63)",
-  " (in 'mlumr_normal_relaxed', line 239, column 13 to column 18)",
-  " (in 'mlumr_normal_relaxed', line 239, column 6 to column 73)",
-  " (in 'mlumr_normal_relaxed', line 240, column 6 to column 21)",
-  " (in 'mlumr_normal_relaxed', line 245, column 8 to column 49)",
-  " (in 'mlumr_normal_relaxed', line 246, column 8 to column 54)",
-  " (in 'mlumr_normal_relaxed', line 244, column 13 to line 247, column 7)",
-  " (in 'mlumr_normal_relaxed', line 242, column 8 to column 37)",
-  " (in 'mlumr_normal_relaxed', line 243, column 8 to column 42)",
-  " (in 'mlumr_normal_relaxed', line 241, column 21 to line 244, column 7)",
-  " (in 'mlumr_normal_relaxed', line 241, column 6 to line 247, column 7)",
-  " (in 'mlumr_normal_relaxed', line 237, column 28 to line 248, column 5)",
-  " (in 'mlumr_normal_relaxed', line 237, column 4 to line 248, column 5)",
-  " (in 'mlumr_normal_relaxed', line 257, column 6 to column 71)",
-  " (in 'mlumr_normal_relaxed', line 258, column 6 to column 81)",
-  " (in 'mlumr_normal_relaxed', line 259, column 6 to column 44)",
-  " (in 'mlumr_normal_relaxed', line 260, column 6 to column 54)",
-  " (in 'mlumr_normal_relaxed', line 261, column 6 to column 44)",
-  " (in 'mlumr_normal_relaxed', line 262, column 6 to column 54)",
-  " (in 'mlumr_normal_relaxed', line 263, column 6 to column 71)",
-  " (in 'mlumr_normal_relaxed', line 256, column 11 to line 264, column 5)",
-  " (in 'mlumr_normal_relaxed', line 250, column 6 to column 74)",
-  " (in 'mlumr_normal_relaxed', line 251, column 6 to line 252, column 45)",
-  " (in 'mlumr_normal_relaxed', line 253, column 6 to column 51)",
-  " (in 'mlumr_normal_relaxed', line 254, column 6 to column 61)",
-  " (in 'mlumr_normal_relaxed', line 255, column 6 to column 70)",
-  " (in 'mlumr_normal_relaxed', line 249, column 19 to line 256, column 5)",
-  " (in 'mlumr_normal_relaxed', line 249, column 4 to line 264, column 5)",
-  " (in 'mlumr_normal_relaxed', line 233, column 2 to line 265, column 3)",
-  " (in 'mlumr_normal_relaxed', line 267, column 2 to column 44)",
-  " (in 'mlumr_normal_relaxed', line 273, column 11 to column 16)",
-  " (in 'mlumr_normal_relaxed', line 273, column 4 to column 42)",
-  " (in 'mlumr_normal_relaxed', line 275, column 6 to column 64)",
-  " (in 'mlumr_normal_relaxed', line 274, column 4 to line 275, column 64)",
-  " (in 'mlumr_normal_relaxed', line 272, column 9 to line 276, column 3)",
-  " (in 'mlumr_normal_relaxed', line 271, column 6 to column 67)",
-  " (in 'mlumr_normal_relaxed', line 270, column 4 to line 271, column 67)",
-  " (in 'mlumr_normal_relaxed', line 269, column 17 to line 272, column 3)",
-  " (in 'mlumr_normal_relaxed', line 269, column 2 to line 276, column 3)",
-  " (in 'mlumr_normal_relaxed', line 278, column 11 to column 16)",
-  " (in 'mlumr_normal_relaxed', line 278, column 4 to column 77)",
-  " (in 'mlumr_normal_relaxed', line 283, column 6 to column 61)",
-  " (in 'mlumr_normal_relaxed', line 284, column 6 to column 69)",
-  " (in 'mlumr_normal_relaxed', line 282, column 11 to line 285, column 5)",
-  " (in 'mlumr_normal_relaxed', line 280, column 6 to column 47)",
-  " (in 'mlumr_normal_relaxed', line 281, column 6 to column 72)",
-  " (in 'mlumr_normal_relaxed', line 279, column 19 to line 282, column 5)",
-  " (in 'mlumr_normal_relaxed', line 279, column 4 to line 285, column 5)",
-  " (in 'mlumr_normal_relaxed', line 277, column 26 to line 286, column 3)",
-  " (in 'mlumr_normal_relaxed', line 277, column 2 to line 286, column 3)",
-  " (in 'mlumr_normal_relaxed', line 155, column 2 to line 156, column 71)",
-  " (in 'mlumr_normal_relaxed', line 157, column 2 to line 158, column 71)",
-  " (in 'mlumr_normal_relaxed', line 159, column 2 to line 160, column 61)",
-  " (in 'mlumr_normal_relaxed', line 161, column 2 to line 163, column 44)",
-  " (in 'mlumr_normal_relaxed', line 165, column 2 to line 166, column 62)",
-  " (in 'mlumr_normal_relaxed', line 175, column 4 to column 42)",
-  " (in 'mlumr_normal_relaxed', line 174, column 9 to line 176, column 3)",
-  " (in 'mlumr_normal_relaxed', line 173, column 6 to column 64)",
-  " (in 'mlumr_normal_relaxed', line 171, column 6 to column 39)",
-  " (in 'mlumr_normal_relaxed', line 170, column 4 to line 173, column 64)",
-  " (in 'mlumr_normal_relaxed', line 169, column 17 to line 174, column 3)",
-  " (in 'mlumr_normal_relaxed', line 169, column 2 to line 176, column 3)",
-  " (in 'mlumr_normal_relaxed', line 180, column 11 to column 16)",
-  " (in 'mlumr_normal_relaxed', line 180, column 4 to column 57)",
-  " (in 'mlumr_normal_relaxed', line 185, column 6 to column 61)",
-  " (in 'mlumr_normal_relaxed', line 186, column 6 to column 47)",
-  " (in 'mlumr_normal_relaxed', line 184, column 11 to line 187, column 5)",
-  " (in 'mlumr_normal_relaxed', line 182, column 6 to column 47)",
-  " (in 'mlumr_normal_relaxed', line 183, column 6 to column 50)",
-  " (in 'mlumr_normal_relaxed', line 181, column 19 to line 184, column 5)",
-  " (in 'mlumr_normal_relaxed', line 181, column 4 to line 187, column 5)",
-  " (in 'mlumr_normal_relaxed', line 179, column 26 to line 188, column 3)",
-  " (in 'mlumr_normal_relaxed', line 179, column 2 to line 188, column 3)",
+  " (in 'mlumr_normal_relaxed', line 142, column 2 to column 24)",
+  " (in 'mlumr_normal_relaxed', line 146, column 2 to column 22)",
+  " (in 'mlumr_normal_relaxed', line 150, column 2 to column 60)",
+  " (in 'mlumr_normal_relaxed', line 151, column 2 to column 29)",
+  " (in 'mlumr_normal_relaxed', line 152, column 2 to column 34)",
+  " (in 'mlumr_normal_relaxed', line 153, column 2 to column 56)",
+  " (in 'mlumr_normal_relaxed', line 154, column 2 to column 69)",
+  " (in 'mlumr_normal_relaxed', line 156, column 2 to column 48)",
+  " (in 'mlumr_normal_relaxed', line 197, column 2 to column 19)",
+  " (in 'mlumr_normal_relaxed', line 198, column 2 to column 24)",
+  " (in 'mlumr_normal_relaxed', line 200, column 2 to column 21)",
+  " (in 'mlumr_normal_relaxed', line 201, column 2 to column 26)",
+  " (in 'mlumr_normal_relaxed', line 202, column 2 to column 26)",
+  " (in 'mlumr_normal_relaxed', line 203, column 2 to column 31)",
+  " (in 'mlumr_normal_relaxed', line 204, column 2 to column 26)",
+  " (in 'mlumr_normal_relaxed', line 205, column 2 to column 31)",
+  " (in 'mlumr_normal_relaxed', line 206, column 2 to column 31)",
+  " (in 'mlumr_normal_relaxed', line 207, column 2 to column 36)",
+  " (in 'mlumr_normal_relaxed', line 209, column 2 to column 27)",
+  " (in 'mlumr_normal_relaxed', line 212, column 2 to column 28)",
+  " (in 'mlumr_normal_relaxed', line 213, column 2 to column 33)",
+  " (in 'mlumr_normal_relaxed', line 216, column 11 to column 16)",
+  " (in 'mlumr_normal_relaxed', line 216, column 4 to column 62)",
+  " (in 'mlumr_normal_relaxed', line 217, column 11 to column 16)",
+  " (in 'mlumr_normal_relaxed', line 217, column 4 to column 77)",
+  " (in 'mlumr_normal_relaxed', line 225, column 6 to column 55)",
+  " (in 'mlumr_normal_relaxed', line 226, column 6 to column 65)",
+  " (in 'mlumr_normal_relaxed', line 227, column 6 to column 39)",
+  " (in 'mlumr_normal_relaxed', line 228, column 6 to column 49)",
+  " (in 'mlumr_normal_relaxed', line 229, column 6 to column 39)",
+  " (in 'mlumr_normal_relaxed', line 230, column 6 to column 49)",
+  " (in 'mlumr_normal_relaxed', line 231, column 6 to column 66)",
+  " (in 'mlumr_normal_relaxed', line 224, column 11 to line 232, column 5)",
+  " (in 'mlumr_normal_relaxed', line 219, column 6 to column 40)",
+  " (in 'mlumr_normal_relaxed', line 220, column 6 to column 50)",
+  " (in 'mlumr_normal_relaxed', line 221, column 6 to column 41)",
+  " (in 'mlumr_normal_relaxed', line 222, column 6 to column 51)",
+  " (in 'mlumr_normal_relaxed', line 223, column 6 to column 55)",
+  " (in 'mlumr_normal_relaxed', line 218, column 19 to line 224, column 5)",
+  " (in 'mlumr_normal_relaxed', line 218, column 4 to line 232, column 5)",
+  " (in 'mlumr_normal_relaxed', line 215, column 2 to line 233, column 3)",
+  " (in 'mlumr_normal_relaxed', line 241, column 11 to column 21)",
+  " (in 'mlumr_normal_relaxed', line 241, column 4 to column 33)",
+  " (in 'mlumr_normal_relaxed', line 242, column 11 to column 21)",
+  " (in 'mlumr_normal_relaxed', line 242, column 4 to column 38)",
+  " (in 'mlumr_normal_relaxed', line 243, column 11 to column 21)",
+  " (in 'mlumr_normal_relaxed', line 243, column 4 to column 31)",
+  " (in 'mlumr_normal_relaxed', line 245, column 13 to column 18)",
+  " (in 'mlumr_normal_relaxed', line 245, column 6 to column 63)",
+  " (in 'mlumr_normal_relaxed', line 246, column 13 to column 18)",
+  " (in 'mlumr_normal_relaxed', line 246, column 6 to column 73)",
+  " (in 'mlumr_normal_relaxed', line 247, column 6 to column 33)",
+  " (in 'mlumr_normal_relaxed', line 252, column 8 to column 49)",
+  " (in 'mlumr_normal_relaxed', line 253, column 8 to column 54)",
+  " (in 'mlumr_normal_relaxed', line 251, column 13 to line 254, column 7)",
+  " (in 'mlumr_normal_relaxed', line 249, column 8 to column 37)",
+  " (in 'mlumr_normal_relaxed', line 250, column 8 to column 42)",
+  " (in 'mlumr_normal_relaxed', line 248, column 21 to line 251, column 7)",
+  " (in 'mlumr_normal_relaxed', line 248, column 6 to line 254, column 7)",
+  " (in 'mlumr_normal_relaxed', line 244, column 28 to line 255, column 5)",
+  " (in 'mlumr_normal_relaxed', line 244, column 4 to line 255, column 5)",
+  " (in 'mlumr_normal_relaxed', line 264, column 6 to column 71)",
+  " (in 'mlumr_normal_relaxed', line 265, column 6 to column 81)",
+  " (in 'mlumr_normal_relaxed', line 266, column 6 to column 44)",
+  " (in 'mlumr_normal_relaxed', line 267, column 6 to column 54)",
+  " (in 'mlumr_normal_relaxed', line 268, column 6 to column 44)",
+  " (in 'mlumr_normal_relaxed', line 269, column 6 to column 54)",
+  " (in 'mlumr_normal_relaxed', line 270, column 6 to column 71)",
+  " (in 'mlumr_normal_relaxed', line 263, column 11 to line 271, column 5)",
+  " (in 'mlumr_normal_relaxed', line 257, column 6 to column 74)",
+  " (in 'mlumr_normal_relaxed', line 258, column 6 to line 259, column 45)",
+  " (in 'mlumr_normal_relaxed', line 260, column 6 to column 51)",
+  " (in 'mlumr_normal_relaxed', line 261, column 6 to column 61)",
+  " (in 'mlumr_normal_relaxed', line 262, column 6 to column 70)",
+  " (in 'mlumr_normal_relaxed', line 256, column 19 to line 263, column 5)",
+  " (in 'mlumr_normal_relaxed', line 256, column 4 to line 271, column 5)",
+  " (in 'mlumr_normal_relaxed', line 240, column 2 to line 272, column 3)",
+  " (in 'mlumr_normal_relaxed', line 274, column 2 to column 44)",
+  " (in 'mlumr_normal_relaxed', line 280, column 11 to column 16)",
+  " (in 'mlumr_normal_relaxed', line 280, column 4 to column 42)",
+  " (in 'mlumr_normal_relaxed', line 282, column 6 to column 64)",
+  " (in 'mlumr_normal_relaxed', line 281, column 4 to line 282, column 64)",
+  " (in 'mlumr_normal_relaxed', line 279, column 9 to line 283, column 3)",
+  " (in 'mlumr_normal_relaxed', line 278, column 6 to column 67)",
+  " (in 'mlumr_normal_relaxed', line 277, column 4 to line 278, column 67)",
+  " (in 'mlumr_normal_relaxed', line 276, column 17 to line 279, column 3)",
+  " (in 'mlumr_normal_relaxed', line 276, column 2 to line 283, column 3)",
+  " (in 'mlumr_normal_relaxed', line 285, column 11 to column 16)",
+  " (in 'mlumr_normal_relaxed', line 285, column 4 to column 77)",
+  " (in 'mlumr_normal_relaxed', line 290, column 6 to column 61)",
+  " (in 'mlumr_normal_relaxed', line 291, column 6 to column 69)",
+  " (in 'mlumr_normal_relaxed', line 289, column 11 to line 292, column 5)",
+  " (in 'mlumr_normal_relaxed', line 287, column 6 to column 47)",
+  " (in 'mlumr_normal_relaxed', line 288, column 6 to column 72)",
+  " (in 'mlumr_normal_relaxed', line 286, column 19 to line 289, column 5)",
+  " (in 'mlumr_normal_relaxed', line 286, column 4 to line 292, column 5)",
+  " (in 'mlumr_normal_relaxed', line 284, column 26 to line 293, column 3)",
+  " (in 'mlumr_normal_relaxed', line 284, column 2 to line 293, column 3)",
+  " (in 'mlumr_normal_relaxed', line 160, column 2 to line 161, column 71)",
+  " (in 'mlumr_normal_relaxed', line 162, column 2 to line 163, column 71)",
+  " (in 'mlumr_normal_relaxed', line 164, column 2 to line 165, column 61)",
+  " (in 'mlumr_normal_relaxed', line 166, column 2 to line 168, column 44)",
+  " (in 'mlumr_normal_relaxed', line 170, column 2 to line 171, column 62)",
+  " (in 'mlumr_normal_relaxed', line 180, column 4 to column 42)",
+  " (in 'mlumr_normal_relaxed', line 179, column 9 to line 181, column 3)",
+  " (in 'mlumr_normal_relaxed', line 178, column 6 to column 64)",
+  " (in 'mlumr_normal_relaxed', line 176, column 6 to column 39)",
+  " (in 'mlumr_normal_relaxed', line 175, column 4 to line 178, column 64)",
+  " (in 'mlumr_normal_relaxed', line 174, column 17 to line 179, column 3)",
+  " (in 'mlumr_normal_relaxed', line 174, column 2 to line 181, column 3)",
+  " (in 'mlumr_normal_relaxed', line 185, column 11 to column 16)",
+  " (in 'mlumr_normal_relaxed', line 185, column 4 to column 57)",
+  " (in 'mlumr_normal_relaxed', line 190, column 6 to column 61)",
+  " (in 'mlumr_normal_relaxed', line 191, column 6 to column 47)",
+  " (in 'mlumr_normal_relaxed', line 189, column 11 to line 192, column 5)",
+  " (in 'mlumr_normal_relaxed', line 187, column 6 to column 47)",
+  " (in 'mlumr_normal_relaxed', line 188, column 6 to column 50)",
+  " (in 'mlumr_normal_relaxed', line 186, column 19 to line 189, column 5)",
+  " (in 'mlumr_normal_relaxed', line 186, column 4 to line 192, column 5)",
+  " (in 'mlumr_normal_relaxed', line 184, column 26 to line 193, column 3)",
+  " (in 'mlumr_normal_relaxed', line 184, column 2 to line 193, column 3)",
   " (in 'mlumr_normal_relaxed', line 74, column 2 to column 21)",
   " (in 'mlumr_normal_relaxed', line 75, column 9 to column 14)",
   " (in 'mlumr_normal_relaxed', line 75, column 2 to column 22)",
@@ -148,46 +148,48 @@ static constexpr std::array<const char*, 202> locations_array__ =
   " (in 'mlumr_normal_relaxed', line 81, column 2 to column 31)",
   " (in 'mlumr_normal_relaxed', line 84, column 8 to column 18)",
   " (in 'mlumr_normal_relaxed', line 84, column 2 to column 41)",
-  " (in 'mlumr_normal_relaxed', line 86, column 2 to column 21)",
-  " (in 'mlumr_normal_relaxed', line 87, column 8 to column 18)",
-  " (in 'mlumr_normal_relaxed', line 87, column 27 to column 32)",
-  " (in 'mlumr_normal_relaxed', line 87, column 34 to column 39)",
-  " (in 'mlumr_normal_relaxed', line 87, column 2 to column 47)",
-  " (in 'mlumr_normal_relaxed', line 89, column 2 to column 26)",
-  " (in 'mlumr_normal_relaxed', line 90, column 2 to column 18)",
-  " (in 'mlumr_normal_relaxed', line 91, column 9 to column 14)",
-  " (in 'mlumr_normal_relaxed', line 91, column 16 to column 18)",
-  " (in 'mlumr_normal_relaxed', line 91, column 2 to column 27)",
+  " (in 'mlumr_normal_relaxed', line 89, column 18 to column 28)",
+  " (in 'mlumr_normal_relaxed', line 89, column 2 to column 41)",
+  " (in 'mlumr_normal_relaxed', line 91, column 2 to column 21)",
   " (in 'mlumr_normal_relaxed', line 92, column 8 to column 18)",
   " (in 'mlumr_normal_relaxed', line 92, column 27 to column 32)",
-  " (in 'mlumr_normal_relaxed', line 92, column 34 to column 36)",
-  " (in 'mlumr_normal_relaxed', line 92, column 2 to column 45)",
-  " (in 'mlumr_normal_relaxed', line 93, column 9 to column 11)",
-  " (in 'mlumr_normal_relaxed', line 93, column 13 to column 15)",
-  " (in 'mlumr_normal_relaxed', line 93, column 2 to column 23)",
-  " (in 'mlumr_normal_relaxed', line 110, column 0 to column 26)",
-  " (in 'mlumr_normal_relaxed', line 111, column 0 to column 33)",
-  " (in 'mlumr_normal_relaxed', line 112, column 0 to column 42)",
-  " (in 'mlumr_normal_relaxed', line 113, column 0 to column 33)",
-  " (in 'mlumr_normal_relaxed', line 115, column 7 to column 12)",
-  " (in 'mlumr_normal_relaxed', line 115, column 0 to column 30)",
-  " (in 'mlumr_normal_relaxed', line 116, column 16 to column 21)",
-  " (in 'mlumr_normal_relaxed', line 116, column 0 to column 37)",
-  " (in 'mlumr_normal_relaxed', line 117, column 0 to column 37)",
-  " (in 'mlumr_normal_relaxed', line 118, column 0 to column 28)",
-  " (in 'mlumr_normal_relaxed', line 128, column 0 to column 26)",
-  " (in 'mlumr_normal_relaxed', line 129, column 0 to column 32)",
-  " (in 'mlumr_normal_relaxed', line 130, column 0 to column 38)",
-  " (in 'mlumr_normal_relaxed', line 131, column 0 to column 29)",
-  " (in 'mlumr_normal_relaxed', line 132, column 2 to column 28)",
-  " (in 'mlumr_normal_relaxed', line 137, column 9 to column 11)",
-  " (in 'mlumr_normal_relaxed', line 145, column 9 to column 11)",
-  " (in 'mlumr_normal_relaxed', line 148, column 9 to column 14)",
-  " (in 'mlumr_normal_relaxed', line 149, column 9 to column 14)",
-  " (in 'mlumr_normal_relaxed', line 151, column 9 to column 14)",
-  " (in 'mlumr_normal_relaxed', line 204, column 9 to column 14)",
-  " (in 'mlumr_normal_relaxed', line 207, column 9 to column 14)",
-  " (in 'mlumr_normal_relaxed', line 208, column 9 to column 19)",
+  " (in 'mlumr_normal_relaxed', line 92, column 34 to column 39)",
+  " (in 'mlumr_normal_relaxed', line 92, column 2 to column 47)",
+  " (in 'mlumr_normal_relaxed', line 94, column 2 to column 26)",
+  " (in 'mlumr_normal_relaxed', line 95, column 2 to column 18)",
+  " (in 'mlumr_normal_relaxed', line 96, column 9 to column 14)",
+  " (in 'mlumr_normal_relaxed', line 96, column 16 to column 18)",
+  " (in 'mlumr_normal_relaxed', line 96, column 2 to column 27)",
+  " (in 'mlumr_normal_relaxed', line 97, column 8 to column 18)",
+  " (in 'mlumr_normal_relaxed', line 97, column 27 to column 32)",
+  " (in 'mlumr_normal_relaxed', line 97, column 34 to column 36)",
+  " (in 'mlumr_normal_relaxed', line 97, column 2 to column 45)",
+  " (in 'mlumr_normal_relaxed', line 98, column 9 to column 11)",
+  " (in 'mlumr_normal_relaxed', line 98, column 13 to column 15)",
+  " (in 'mlumr_normal_relaxed', line 98, column 2 to column 23)",
+  " (in 'mlumr_normal_relaxed', line 115, column 0 to column 26)",
+  " (in 'mlumr_normal_relaxed', line 116, column 0 to column 33)",
+  " (in 'mlumr_normal_relaxed', line 117, column 0 to column 42)",
+  " (in 'mlumr_normal_relaxed', line 118, column 0 to column 33)",
+  " (in 'mlumr_normal_relaxed', line 120, column 7 to column 12)",
+  " (in 'mlumr_normal_relaxed', line 120, column 0 to column 30)",
+  " (in 'mlumr_normal_relaxed', line 121, column 16 to column 21)",
+  " (in 'mlumr_normal_relaxed', line 121, column 0 to column 37)",
+  " (in 'mlumr_normal_relaxed', line 122, column 0 to column 37)",
+  " (in 'mlumr_normal_relaxed', line 123, column 0 to column 28)",
+  " (in 'mlumr_normal_relaxed', line 133, column 0 to column 26)",
+  " (in 'mlumr_normal_relaxed', line 134, column 0 to column 32)",
+  " (in 'mlumr_normal_relaxed', line 135, column 0 to column 38)",
+  " (in 'mlumr_normal_relaxed', line 136, column 0 to column 29)",
+  " (in 'mlumr_normal_relaxed', line 137, column 2 to column 28)",
+  " (in 'mlumr_normal_relaxed', line 142, column 9 to column 11)",
+  " (in 'mlumr_normal_relaxed', line 150, column 9 to column 11)",
+  " (in 'mlumr_normal_relaxed', line 153, column 9 to column 14)",
+  " (in 'mlumr_normal_relaxed', line 154, column 9 to column 14)",
+  " (in 'mlumr_normal_relaxed', line 156, column 9 to column 14)",
+  " (in 'mlumr_normal_relaxed', line 209, column 9 to column 14)",
+  " (in 'mlumr_normal_relaxed', line 212, column 9 to column 14)",
+  " (in 'mlumr_normal_relaxed', line 213, column 9 to column 19)",
   " (in 'mlumr_normal_relaxed', line 24, column 7 to column 54)",
   " (in 'mlumr_normal_relaxed', line 23, column 17 to column 57)",
   " (in 'mlumr_normal_relaxed', line 23, column 2 to line 24, column 54)",
@@ -315,12 +317,12 @@ log_prior_scalar(const T0__& x, const T1__& location, const T2__& scale,
   // suppress unused var warning
   (void) DUMMY_VAR__;
   try {
-    current_statement__ = 176;
+    current_statement__ = 178;
     if (stan::math::logical_eq(dist, 0)) {
-      current_statement__ = 175;
+      current_statement__ = 177;
       return stan::math::normal_lpdf<false>(x, location, scale);
     } else {
-      current_statement__ = 174;
+      current_statement__ = 176;
       return stan::math::student_t_lpdf<false>(x, df, location, scale);
     }
   } catch (const std::exception& e) {
@@ -360,12 +362,12 @@ log_prior_vector(const T0__& x_arg__, const T1__& location_arg__, const T2__&
   // suppress unused var warning
   (void) DUMMY_VAR__;
   try {
-    current_statement__ = 180;
+    current_statement__ = 182;
     if (stan::math::logical_eq(dist, 0)) {
-      current_statement__ = 179;
+      current_statement__ = 181;
       return stan::math::normal_lpdf<false>(x, location, scale);
     } else {
-      current_statement__ = 178;
+      current_statement__ = 180;
       return stan::math::student_t_lpdf<false>(x, df, location, scale);
     }
   } catch (const std::exception& e) {
@@ -398,17 +400,17 @@ log_prior_sigma(const T0__& sigma, const T1__& location, const T2__& scale,
   // suppress unused var warning
   (void) DUMMY_VAR__;
   try {
-    current_statement__ = 186;
+    current_statement__ = 188;
     if (stan::math::logical_eq(dist, 0)) {
-      current_statement__ = 185;
+      current_statement__ = 187;
       return stan::math::normal_lpdf<false>(sigma, location, scale);
     } else {
-      current_statement__ = 184;
+      current_statement__ = 186;
       if (stan::math::logical_eq(dist, 1)) {
-        current_statement__ = 183;
+        current_statement__ = 185;
         return stan::math::student_t_lpdf<false>(sigma, df, location, scale);
       } else {
-        current_statement__ = 182;
+        current_statement__ = 184;
         return stan::math::exponential_lpdf<false>(sigma,
                  stan::math::inv(scale));
       }
@@ -439,12 +441,12 @@ log_prior_std_vector(const T0__& z_arg__, const T1__& dist, const T2__& df,
   // suppress unused var warning
   (void) DUMMY_VAR__;
   try {
-    current_statement__ = 190;
+    current_statement__ = 192;
     if (stan::math::logical_eq(dist, 0)) {
-      current_statement__ = 189;
+      current_statement__ = 191;
       return stan::math::std_normal_lpdf<false>(z);
     } else {
-      current_statement__ = 188;
+      current_statement__ = 190;
       return stan::math::student_t_lpdf<false>(z, df, static_cast<double>(0),
                static_cast<double>(1));
     }
@@ -470,7 +472,7 @@ log_mean_exp_vec(const T0__& x_arg__, std::ostream* pstream__) {
   // suppress unused var warning
   (void) DUMMY_VAR__;
   try {
-    current_statement__ = 192;
+    current_statement__ = 194;
     return (stan::math::log_sum_exp(x) -
            stan::math::log(stan::math::num_elements(x)));
   } catch (const std::exception& e) {
@@ -500,7 +502,7 @@ log_weighted_mean_exp_vec(const T0__& log_x_arg__, const T1__& weights_arg__,
   // suppress unused var warning
   (void) DUMMY_VAR__;
   try {
-    current_statement__ = 194;
+    current_statement__ = 196;
     return (stan::math::log_sum_exp(
               stan::math::add(stan::math::log(weights), log_x))
            - stan::math::log_sum_exp(stan::math::log(weights)));
@@ -527,18 +529,18 @@ exp_difference(const T0__& log_x, const T1__& log_y, std::ostream* pstream__) {
   // suppress unused var warning
   (void) DUMMY_VAR__;
   try {
-    current_statement__ = 200;
+    current_statement__ = 202;
     if (stan::math::logical_eq(log_x, log_y)) {
-      current_statement__ = 199;
+      current_statement__ = 201;
       return stan::math::promote_scalar<local_scalar_t__>(0);
     } else {
-      current_statement__ = 198;
+      current_statement__ = 200;
       if (stan::math::logical_gt(log_x, log_y)) {
-        current_statement__ = 197;
+        current_statement__ = 199;
         return stan::math::exp((log_x +
                  stan::math::log1m_exp((log_y - log_x))));
       } else {
-        current_statement__ = 196;
+        current_statement__ = 198;
         return -(stan::math::exp((log_y +
                    stan::math::log1m_exp((log_x - log_y)))));
       }
@@ -557,6 +559,7 @@ private:
   int n_agd_rows;
   std::vector<double> y_agd;
   std::vector<double> se_agd;
+  Eigen::Matrix<double,-1,1> agd_weight_data__;
   int n_int;
   std::vector<Eigen::Matrix<double,-1,-1>> X_int;
   int qr;
@@ -579,6 +582,7 @@ private:
   int link;
   Eigen::Map<Eigen::Matrix<double,-1,1>> y_ipd{nullptr, 0};
   Eigen::Map<Eigen::Matrix<double,-1,-1>> X_ipd{nullptr, 0, 0};
+  Eigen::Map<Eigen::Matrix<double,-1,1>> agd_weight{nullptr, 0};
   Eigen::Map<Eigen::Matrix<double,-1,-1>> Xq_ipd{nullptr, 0, 0};
   Eigen::Map<Eigen::Matrix<double,-1,-1>> R_inv{nullptr, 0, 0};
   Eigen::Map<Eigen::Matrix<double,-1,1>> prior_beta_mean{nullptr, 0};
@@ -700,21 +704,46 @@ public:
       current_statement__ = 133;
       stan::math::check_greater_or_equal(function__, "se_agd", se_agd, 0);
       current_statement__ = 134;
+      stan::math::validate_non_negative_index("agd_weight", "n_agd_rows",
+        n_agd_rows);
+      current_statement__ = 135;
+      context__.validate_dims("data initialization", "agd_weight", "double",
+        std::vector<size_t>{static_cast<size_t>(n_agd_rows)});
+      agd_weight_data__ = Eigen::Matrix<double,-1,1>::Constant(n_agd_rows,
+                            std::numeric_limits<double>::quiet_NaN());
+      new (&agd_weight)
+        Eigen::Map<Eigen::Matrix<double,-1,1>>(agd_weight_data__.data(),
+        n_agd_rows);
+      {
+        std::vector<local_scalar_t__> agd_weight_flat__;
+        current_statement__ = 135;
+        agd_weight_flat__ = context__.vals_r("agd_weight");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= n_agd_rows; ++sym1__) {
+          stan::model::assign(agd_weight, agd_weight_flat__[(pos__ - 1)],
+            "assigning variable agd_weight", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      current_statement__ = 135;
+      stan::math::check_greater_or_equal(function__, "agd_weight",
+        agd_weight, 0);
+      current_statement__ = 136;
       context__.validate_dims("data initialization", "n_int", "int",
         std::vector<size_t>{});
       n_int = std::numeric_limits<int>::min();
-      current_statement__ = 134;
+      current_statement__ = 136;
       n_int = context__.vals_i("n_int")[(1 - 1)];
-      current_statement__ = 134;
+      current_statement__ = 136;
       stan::math::check_greater_or_equal(function__, "n_int", n_int, 1);
-      current_statement__ = 135;
+      current_statement__ = 137;
       stan::math::validate_non_negative_index("X_int", "n_agd_rows",
         n_agd_rows);
-      current_statement__ = 136;
-      stan::math::validate_non_negative_index("X_int", "n_int", n_int);
-      current_statement__ = 137;
-      stan::math::validate_non_negative_index("X_int", "n_cov", n_cov);
       current_statement__ = 138;
+      stan::math::validate_non_negative_index("X_int", "n_int", n_int);
+      current_statement__ = 139;
+      stan::math::validate_non_negative_index("X_int", "n_cov", n_cov);
+      current_statement__ = 140;
       context__.validate_dims("data initialization", "X_int", "double",
         std::vector<size_t>{static_cast<size_t>(n_agd_rows),
           static_cast<size_t>(n_int), static_cast<size_t>(n_cov)});
@@ -723,7 +752,7 @@ public:
                   std::numeric_limits<double>::quiet_NaN()));
       {
         std::vector<local_scalar_t__> X_int_flat__;
-        current_statement__ = 138;
+        current_statement__ = 140;
         X_int_flat__ = context__.vals_r("X_int");
         pos__ = 1;
         for (int sym1__ = 1; sym1__ <= n_cov; ++sym1__) {
@@ -738,29 +767,29 @@ public:
           }
         }
       }
-      current_statement__ = 139;
+      current_statement__ = 141;
       context__.validate_dims("data initialization", "qr", "int",
         std::vector<size_t>{});
       qr = std::numeric_limits<int>::min();
-      current_statement__ = 139;
+      current_statement__ = 141;
       qr = context__.vals_i("qr")[(1 - 1)];
-      current_statement__ = 139;
+      current_statement__ = 141;
       stan::math::check_greater_or_equal(function__, "qr", qr, 0);
-      current_statement__ = 139;
+      current_statement__ = 141;
       stan::math::check_less_or_equal(function__, "qr", qr, 1);
-      current_statement__ = 140;
+      current_statement__ = 142;
       context__.validate_dims("data initialization", "nB", "int",
         std::vector<size_t>{});
       nB = std::numeric_limits<int>::min();
-      current_statement__ = 140;
-      nB = context__.vals_i("nB")[(1 - 1)];
-      current_statement__ = 140;
-      stan::math::check_greater_or_equal(function__, "nB", nB, 1);
-      current_statement__ = 141;
-      stan::math::validate_non_negative_index("Xq_ipd", "n_ipd", n_ipd);
       current_statement__ = 142;
-      stan::math::validate_non_negative_index("Xq_ipd", "nB", nB);
+      nB = context__.vals_i("nB")[(1 - 1)];
+      current_statement__ = 142;
+      stan::math::check_greater_or_equal(function__, "nB", nB, 1);
       current_statement__ = 143;
+      stan::math::validate_non_negative_index("Xq_ipd", "n_ipd", n_ipd);
+      current_statement__ = 144;
+      stan::math::validate_non_negative_index("Xq_ipd", "nB", nB);
+      current_statement__ = 145;
       context__.validate_dims("data initialization", "Xq_ipd", "double",
         std::vector<size_t>{static_cast<size_t>(n_ipd),
           static_cast<size_t>(nB)});
@@ -771,7 +800,7 @@ public:
         nB);
       {
         std::vector<local_scalar_t__> Xq_ipd_flat__;
-        current_statement__ = 143;
+        current_statement__ = 145;
         Xq_ipd_flat__ = context__.vals_r("Xq_ipd");
         pos__ = 1;
         for (int sym1__ = 1; sym1__ <= nB; ++sym1__) {
@@ -783,14 +812,14 @@ public:
           }
         }
       }
-      current_statement__ = 144;
+      current_statement__ = 146;
       stan::math::validate_non_negative_index("Xq_int", "n_agd_rows",
         n_agd_rows);
-      current_statement__ = 145;
-      stan::math::validate_non_negative_index("Xq_int", "n_int", n_int);
-      current_statement__ = 146;
-      stan::math::validate_non_negative_index("Xq_int", "nB", nB);
       current_statement__ = 147;
+      stan::math::validate_non_negative_index("Xq_int", "n_int", n_int);
+      current_statement__ = 148;
+      stan::math::validate_non_negative_index("Xq_int", "nB", nB);
+      current_statement__ = 149;
       context__.validate_dims("data initialization", "Xq_int", "double",
         std::vector<size_t>{static_cast<size_t>(n_agd_rows),
           static_cast<size_t>(n_int), static_cast<size_t>(nB)});
@@ -799,7 +828,7 @@ public:
                    std::numeric_limits<double>::quiet_NaN()));
       {
         std::vector<local_scalar_t__> Xq_int_flat__;
-        current_statement__ = 147;
+        current_statement__ = 149;
         Xq_int_flat__ = context__.vals_r("Xq_int");
         pos__ = 1;
         for (int sym1__ = 1; sym1__ <= nB; ++sym1__) {
@@ -814,11 +843,11 @@ public:
           }
         }
       }
-      current_statement__ = 148;
-      stan::math::validate_non_negative_index("R_inv", "nB", nB);
-      current_statement__ = 149;
-      stan::math::validate_non_negative_index("R_inv", "nB", nB);
       current_statement__ = 150;
+      stan::math::validate_non_negative_index("R_inv", "nB", nB);
+      current_statement__ = 151;
+      stan::math::validate_non_negative_index("R_inv", "nB", nB);
+      current_statement__ = 152;
       context__.validate_dims("data initialization", "R_inv", "double",
         std::vector<size_t>{static_cast<size_t>(nB), static_cast<size_t>(nB)});
       R_inv_data__ = Eigen::Matrix<double,-1,-1>::Constant(nB, nB,
@@ -827,7 +856,7 @@ public:
         Eigen::Map<Eigen::Matrix<double,-1,-1>>(R_inv_data__.data(), nB, nB);
       {
         std::vector<local_scalar_t__> R_inv_flat__;
-        current_statement__ = 150;
+        current_statement__ = 152;
         R_inv_flat__ = context__.vals_r("R_inv");
         pos__ = 1;
         for (int sym1__ = 1; sym1__ <= nB; ++sym1__) {
@@ -839,48 +868,48 @@ public:
           }
         }
       }
-      current_statement__ = 151;
+      current_statement__ = 153;
       context__.validate_dims("data initialization", "prior_intercept_mean",
         "double", std::vector<size_t>{});
       prior_intercept_mean = std::numeric_limits<double>::quiet_NaN();
-      current_statement__ = 151;
+      current_statement__ = 153;
       prior_intercept_mean = context__.vals_r("prior_intercept_mean")[(1 -
         1)];
-      current_statement__ = 152;
+      current_statement__ = 154;
       context__.validate_dims("data initialization", "prior_intercept_sd",
         "double", std::vector<size_t>{});
       prior_intercept_sd = std::numeric_limits<double>::quiet_NaN();
-      current_statement__ = 152;
+      current_statement__ = 154;
       prior_intercept_sd = context__.vals_r("prior_intercept_sd")[(1 - 1)];
-      current_statement__ = 152;
+      current_statement__ = 154;
       stan::math::check_greater_or_equal(function__, "prior_intercept_sd",
         prior_intercept_sd, 0);
-      current_statement__ = 153;
+      current_statement__ = 155;
       context__.validate_dims("data initialization", "prior_intercept_dist",
         "int", std::vector<size_t>{});
       prior_intercept_dist = std::numeric_limits<int>::min();
-      current_statement__ = 153;
+      current_statement__ = 155;
       prior_intercept_dist = context__.vals_i("prior_intercept_dist")[(1 -
         1)];
-      current_statement__ = 153;
+      current_statement__ = 155;
       stan::math::check_greater_or_equal(function__, "prior_intercept_dist",
         prior_intercept_dist, 0);
-      current_statement__ = 153;
+      current_statement__ = 155;
       stan::math::check_less_or_equal(function__, "prior_intercept_dist",
         prior_intercept_dist, 1);
-      current_statement__ = 154;
+      current_statement__ = 156;
       context__.validate_dims("data initialization", "prior_intercept_df",
         "double", std::vector<size_t>{});
       prior_intercept_df = std::numeric_limits<double>::quiet_NaN();
-      current_statement__ = 154;
+      current_statement__ = 156;
       prior_intercept_df = context__.vals_r("prior_intercept_df")[(1 - 1)];
-      current_statement__ = 154;
+      current_statement__ = 156;
       stan::math::check_greater_or_equal(function__, "prior_intercept_df",
         prior_intercept_df, 0);
-      current_statement__ = 155;
+      current_statement__ = 157;
       stan::math::validate_non_negative_index("prior_beta_mean", "n_cov",
         n_cov);
-      current_statement__ = 156;
+      current_statement__ = 158;
       context__.validate_dims("data initialization", "prior_beta_mean",
         "double", std::vector<size_t>{static_cast<size_t>(n_cov)});
       prior_beta_mean_data__ = Eigen::Matrix<double,-1,1>::Constant(n_cov,
@@ -890,7 +919,7 @@ public:
         n_cov);
       {
         std::vector<local_scalar_t__> prior_beta_mean_flat__;
-        current_statement__ = 156;
+        current_statement__ = 158;
         prior_beta_mean_flat__ = context__.vals_r("prior_beta_mean");
         pos__ = 1;
         for (int sym1__ = 1; sym1__ <= n_cov; ++sym1__) {
@@ -900,9 +929,9 @@ public:
           pos__ = (pos__ + 1);
         }
       }
-      current_statement__ = 157;
+      current_statement__ = 159;
       stan::math::validate_non_negative_index("prior_beta_sd", "n_cov", n_cov);
-      current_statement__ = 158;
+      current_statement__ = 160;
       context__.validate_dims("data initialization", "prior_beta_sd",
         "double", std::vector<size_t>{static_cast<size_t>(n_cov)});
       prior_beta_sd_data__ = Eigen::Matrix<double,-1,1>::Constant(n_cov,
@@ -912,7 +941,7 @@ public:
         n_cov);
       {
         std::vector<local_scalar_t__> prior_beta_sd_flat__;
-        current_statement__ = 158;
+        current_statement__ = 160;
         prior_beta_sd_flat__ = context__.vals_r("prior_beta_sd");
         pos__ = 1;
         for (int sym1__ = 1; sym1__ <= n_cov; ++sym1__) {
@@ -922,93 +951,93 @@ public:
           pos__ = (pos__ + 1);
         }
       }
-      current_statement__ = 158;
+      current_statement__ = 160;
       stan::math::check_greater_or_equal(function__, "prior_beta_sd",
         prior_beta_sd, 0);
-      current_statement__ = 159;
+      current_statement__ = 161;
       context__.validate_dims("data initialization", "prior_beta_dist",
         "int", std::vector<size_t>{});
       prior_beta_dist = std::numeric_limits<int>::min();
-      current_statement__ = 159;
+      current_statement__ = 161;
       prior_beta_dist = context__.vals_i("prior_beta_dist")[(1 - 1)];
-      current_statement__ = 159;
+      current_statement__ = 161;
       stan::math::check_greater_or_equal(function__, "prior_beta_dist",
         prior_beta_dist, 0);
-      current_statement__ = 159;
+      current_statement__ = 161;
       stan::math::check_less_or_equal(function__, "prior_beta_dist",
         prior_beta_dist, 1);
-      current_statement__ = 160;
+      current_statement__ = 162;
       context__.validate_dims("data initialization", "prior_beta_df",
         "double", std::vector<size_t>{});
       prior_beta_df = std::numeric_limits<double>::quiet_NaN();
-      current_statement__ = 160;
+      current_statement__ = 162;
       prior_beta_df = context__.vals_r("prior_beta_df")[(1 - 1)];
-      current_statement__ = 160;
+      current_statement__ = 162;
       stan::math::check_greater_or_equal(function__, "prior_beta_df",
         prior_beta_df, 0);
-      current_statement__ = 161;
+      current_statement__ = 163;
       context__.validate_dims("data initialization", "prior_sigma_location",
         "double", std::vector<size_t>{});
       prior_sigma_location = std::numeric_limits<double>::quiet_NaN();
-      current_statement__ = 161;
+      current_statement__ = 163;
       prior_sigma_location = context__.vals_r("prior_sigma_location")[(1 -
         1)];
-      current_statement__ = 162;
+      current_statement__ = 164;
       context__.validate_dims("data initialization", "prior_sigma_scale",
         "double", std::vector<size_t>{});
       prior_sigma_scale = std::numeric_limits<double>::quiet_NaN();
-      current_statement__ = 162;
+      current_statement__ = 164;
       prior_sigma_scale = context__.vals_r("prior_sigma_scale")[(1 - 1)];
-      current_statement__ = 162;
+      current_statement__ = 164;
       stan::math::check_greater_or_equal(function__, "prior_sigma_scale",
         prior_sigma_scale, 0);
-      current_statement__ = 163;
+      current_statement__ = 165;
       context__.validate_dims("data initialization", "prior_sigma_dist",
         "int", std::vector<size_t>{});
       prior_sigma_dist = std::numeric_limits<int>::min();
-      current_statement__ = 163;
+      current_statement__ = 165;
       prior_sigma_dist = context__.vals_i("prior_sigma_dist")[(1 - 1)];
-      current_statement__ = 163;
+      current_statement__ = 165;
       stan::math::check_greater_or_equal(function__, "prior_sigma_dist",
         prior_sigma_dist, 0);
-      current_statement__ = 163;
+      current_statement__ = 165;
       stan::math::check_less_or_equal(function__, "prior_sigma_dist",
         prior_sigma_dist, 2);
-      current_statement__ = 164;
+      current_statement__ = 166;
       context__.validate_dims("data initialization", "prior_sigma_df",
         "double", std::vector<size_t>{});
       prior_sigma_df = std::numeric_limits<double>::quiet_NaN();
-      current_statement__ = 164;
+      current_statement__ = 166;
       prior_sigma_df = context__.vals_r("prior_sigma_df")[(1 - 1)];
-      current_statement__ = 164;
+      current_statement__ = 166;
       stan::math::check_greater_or_equal(function__, "prior_sigma_df",
         prior_sigma_df, 0);
-      current_statement__ = 165;
+      current_statement__ = 167;
       context__.validate_dims("data initialization", "link", "int",
         std::vector<size_t>{});
       link = std::numeric_limits<int>::min();
-      current_statement__ = 165;
-      link = context__.vals_i("link")[(1 - 1)];
-      current_statement__ = 165;
-      stan::math::check_greater_or_equal(function__, "link", link, 1);
-      current_statement__ = 165;
-      stan::math::check_less_or_equal(function__, "link", link, 2);
-      current_statement__ = 166;
-      stan::math::validate_non_negative_index("beta_tilde", "nB", nB);
       current_statement__ = 167;
-      stan::math::validate_non_negative_index("allbeta", "nB", nB);
+      link = context__.vals_i("link")[(1 - 1)];
+      current_statement__ = 167;
+      stan::math::check_greater_or_equal(function__, "link", link, 1);
+      current_statement__ = 167;
+      stan::math::check_less_or_equal(function__, "link", link, 2);
       current_statement__ = 168;
-      stan::math::validate_non_negative_index("beta_index", "n_cov", n_cov);
+      stan::math::validate_non_negative_index("beta_tilde", "nB", nB);
       current_statement__ = 169;
+      stan::math::validate_non_negative_index("allbeta", "nB", nB);
+      current_statement__ = 170;
+      stan::math::validate_non_negative_index("beta_index", "n_cov", n_cov);
+      current_statement__ = 171;
       stan::math::validate_non_negative_index("beta_comparator", "n_cov",
         n_cov);
-      current_statement__ = 170;
-      stan::math::validate_non_negative_index("theta_ipd", "n_ipd", n_ipd);
-      current_statement__ = 171;
-      stan::math::validate_non_negative_index("delta_beta", "n_cov", n_cov);
       current_statement__ = 172;
-      stan::math::validate_non_negative_index("log_lik_ipd", "n_ipd", n_ipd);
+      stan::math::validate_non_negative_index("theta_ipd", "n_ipd", n_ipd);
       current_statement__ = 173;
+      stan::math::validate_non_negative_index("delta_beta", "n_cov", n_cov);
+      current_statement__ = 174;
+      stan::math::validate_non_negative_index("log_lik_ipd", "n_ipd", n_ipd);
+      current_statement__ = 175;
       stan::math::validate_non_negative_index("log_lik_agd", "n_agd_rows",
         n_agd_rows);
     } catch (const std::exception& e) {
@@ -1526,7 +1555,9 @@ public:
                 stan::model::rvalue(X_int, "X_int", stan::model::index_uni(k)),
                 beta_comparator)), "assigning variable y_cmp_k");
           current_statement__ = 52;
-          stan::model::assign(weights, 1, "assigning variable weights",
+          stan::model::assign(weights,
+            stan::model::rvalue(agd_weight, "agd_weight",
+              stan::model::index_uni(k)), "assigning variable weights",
             stan::model::index_uni(k));
           current_statement__ = 59;
           if (stan::math::logical_eq(link, 1)) {

--- a/src/stanExports_mlumr_normal_spfa.h
+++ b/src/stanExports_mlumr_normal_spfa.h
@@ -13,125 +13,125 @@ namespace model_mlumr_normal_spfa_namespace {
 using stan::model::model_base_crtp;
 using namespace stan::math;
 stan::math::profile_map profiles__;
-static constexpr std::array<const char*, 196> locations_array__ =
+static constexpr std::array<const char*, 198> locations_array__ =
   {" (found before start of program)",
-  " (in 'mlumr_normal_spfa', line 136, column 2 to column 24)",
-  " (in 'mlumr_normal_spfa', line 137, column 2 to column 22)",
-  " (in 'mlumr_normal_spfa', line 141, column 2 to column 60)",
-  " (in 'mlumr_normal_spfa', line 142, column 2 to column 29)",
-  " (in 'mlumr_normal_spfa', line 143, column 2 to column 34)",
-  " (in 'mlumr_normal_spfa', line 144, column 2 to column 50)",
-  " (in 'mlumr_normal_spfa', line 146, column 2 to column 48)",
-  " (in 'mlumr_normal_spfa', line 186, column 2 to column 19)",
-  " (in 'mlumr_normal_spfa', line 187, column 2 to column 24)",
-  " (in 'mlumr_normal_spfa', line 189, column 2 to column 21)",
-  " (in 'mlumr_normal_spfa', line 190, column 2 to column 26)",
-  " (in 'mlumr_normal_spfa', line 191, column 2 to column 26)",
-  " (in 'mlumr_normal_spfa', line 192, column 2 to column 31)",
-  " (in 'mlumr_normal_spfa', line 193, column 2 to column 26)",
-  " (in 'mlumr_normal_spfa', line 194, column 2 to column 31)",
-  " (in 'mlumr_normal_spfa', line 195, column 2 to column 31)",
-  " (in 'mlumr_normal_spfa', line 196, column 2 to column 36)",
-  " (in 'mlumr_normal_spfa', line 199, column 2 to column 28)",
-  " (in 'mlumr_normal_spfa', line 200, column 2 to column 33)",
-  " (in 'mlumr_normal_spfa', line 203, column 11 to column 16)",
-  " (in 'mlumr_normal_spfa', line 203, column 4 to column 56)",
-  " (in 'mlumr_normal_spfa', line 204, column 11 to column 16)",
-  " (in 'mlumr_normal_spfa', line 204, column 4 to column 66)",
-  " (in 'mlumr_normal_spfa', line 212, column 6 to column 55)",
-  " (in 'mlumr_normal_spfa', line 213, column 6 to column 65)",
-  " (in 'mlumr_normal_spfa', line 214, column 6 to column 39)",
-  " (in 'mlumr_normal_spfa', line 215, column 6 to column 49)",
-  " (in 'mlumr_normal_spfa', line 216, column 6 to column 39)",
-  " (in 'mlumr_normal_spfa', line 217, column 6 to column 49)",
-  " (in 'mlumr_normal_spfa', line 218, column 6 to column 66)",
-  " (in 'mlumr_normal_spfa', line 211, column 11 to line 219, column 5)",
-  " (in 'mlumr_normal_spfa', line 206, column 6 to column 40)",
-  " (in 'mlumr_normal_spfa', line 207, column 6 to column 50)",
-  " (in 'mlumr_normal_spfa', line 208, column 6 to column 41)",
-  " (in 'mlumr_normal_spfa', line 209, column 6 to column 51)",
-  " (in 'mlumr_normal_spfa', line 210, column 6 to column 55)",
-  " (in 'mlumr_normal_spfa', line 205, column 19 to line 211, column 5)",
-  " (in 'mlumr_normal_spfa', line 205, column 4 to line 219, column 5)",
-  " (in 'mlumr_normal_spfa', line 202, column 2 to line 220, column 3)",
-  " (in 'mlumr_normal_spfa', line 226, column 11 to column 21)",
-  " (in 'mlumr_normal_spfa', line 226, column 4 to column 33)",
-  " (in 'mlumr_normal_spfa', line 227, column 11 to column 21)",
-  " (in 'mlumr_normal_spfa', line 227, column 4 to column 38)",
-  " (in 'mlumr_normal_spfa', line 228, column 11 to column 21)",
-  " (in 'mlumr_normal_spfa', line 228, column 4 to column 31)",
-  " (in 'mlumr_normal_spfa', line 230, column 13 to column 18)",
-  " (in 'mlumr_normal_spfa', line 230, column 6 to column 57)",
-  " (in 'mlumr_normal_spfa', line 231, column 13 to column 18)",
-  " (in 'mlumr_normal_spfa', line 231, column 6 to column 62)",
-  " (in 'mlumr_normal_spfa', line 232, column 6 to column 21)",
-  " (in 'mlumr_normal_spfa', line 237, column 8 to column 49)",
-  " (in 'mlumr_normal_spfa', line 238, column 8 to column 54)",
-  " (in 'mlumr_normal_spfa', line 236, column 13 to line 239, column 7)",
-  " (in 'mlumr_normal_spfa', line 234, column 8 to column 37)",
-  " (in 'mlumr_normal_spfa', line 235, column 8 to column 42)",
-  " (in 'mlumr_normal_spfa', line 233, column 21 to line 236, column 7)",
-  " (in 'mlumr_normal_spfa', line 233, column 6 to line 239, column 7)",
-  " (in 'mlumr_normal_spfa', line 229, column 28 to line 240, column 5)",
-  " (in 'mlumr_normal_spfa', line 229, column 4 to line 240, column 5)",
-  " (in 'mlumr_normal_spfa', line 249, column 6 to column 71)",
-  " (in 'mlumr_normal_spfa', line 250, column 6 to column 81)",
-  " (in 'mlumr_normal_spfa', line 251, column 6 to column 44)",
-  " (in 'mlumr_normal_spfa', line 252, column 6 to column 54)",
-  " (in 'mlumr_normal_spfa', line 253, column 6 to column 44)",
-  " (in 'mlumr_normal_spfa', line 254, column 6 to column 54)",
-  " (in 'mlumr_normal_spfa', line 255, column 6 to column 71)",
-  " (in 'mlumr_normal_spfa', line 248, column 11 to line 256, column 5)",
-  " (in 'mlumr_normal_spfa', line 242, column 6 to column 74)",
-  " (in 'mlumr_normal_spfa', line 243, column 6 to line 244, column 45)",
-  " (in 'mlumr_normal_spfa', line 245, column 6 to column 51)",
-  " (in 'mlumr_normal_spfa', line 246, column 6 to column 61)",
-  " (in 'mlumr_normal_spfa', line 247, column 6 to column 70)",
-  " (in 'mlumr_normal_spfa', line 241, column 19 to line 248, column 5)",
-  " (in 'mlumr_normal_spfa', line 241, column 4 to line 256, column 5)",
-  " (in 'mlumr_normal_spfa', line 225, column 2 to line 257, column 3)",
-  " (in 'mlumr_normal_spfa', line 263, column 11 to column 16)",
-  " (in 'mlumr_normal_spfa', line 263, column 4 to column 42)",
-  " (in 'mlumr_normal_spfa', line 265, column 6 to column 64)",
-  " (in 'mlumr_normal_spfa', line 264, column 4 to line 265, column 64)",
-  " (in 'mlumr_normal_spfa', line 262, column 9 to line 266, column 3)",
-  " (in 'mlumr_normal_spfa', line 261, column 6 to column 67)",
-  " (in 'mlumr_normal_spfa', line 260, column 4 to line 261, column 67)",
-  " (in 'mlumr_normal_spfa', line 259, column 17 to line 262, column 3)",
-  " (in 'mlumr_normal_spfa', line 259, column 2 to line 266, column 3)",
-  " (in 'mlumr_normal_spfa', line 269, column 11 to column 16)",
-  " (in 'mlumr_normal_spfa', line 269, column 4 to column 66)",
-  " (in 'mlumr_normal_spfa', line 274, column 6 to column 61)",
-  " (in 'mlumr_normal_spfa', line 275, column 6 to column 69)",
-  " (in 'mlumr_normal_spfa', line 273, column 11 to line 276, column 5)",
-  " (in 'mlumr_normal_spfa', line 271, column 6 to column 47)",
-  " (in 'mlumr_normal_spfa', line 272, column 6 to column 72)",
-  " (in 'mlumr_normal_spfa', line 270, column 19 to line 273, column 5)",
-  " (in 'mlumr_normal_spfa', line 270, column 4 to line 276, column 5)",
-  " (in 'mlumr_normal_spfa', line 268, column 26 to line 277, column 3)",
-  " (in 'mlumr_normal_spfa', line 268, column 2 to line 277, column 3)",
-  " (in 'mlumr_normal_spfa', line 150, column 2 to line 151, column 71)",
-  " (in 'mlumr_normal_spfa', line 152, column 2 to line 153, column 71)",
-  " (in 'mlumr_normal_spfa', line 154, column 2 to line 155, column 61)",
-  " (in 'mlumr_normal_spfa', line 157, column 2 to line 158, column 62)",
-  " (in 'mlumr_normal_spfa', line 167, column 4 to column 42)",
-  " (in 'mlumr_normal_spfa', line 166, column 9 to line 168, column 3)",
-  " (in 'mlumr_normal_spfa', line 165, column 6 to column 58)",
-  " (in 'mlumr_normal_spfa', line 163, column 6 to column 39)",
-  " (in 'mlumr_normal_spfa', line 162, column 4 to line 165, column 58)",
-  " (in 'mlumr_normal_spfa', line 161, column 17 to line 166, column 3)",
-  " (in 'mlumr_normal_spfa', line 161, column 2 to line 168, column 3)",
-  " (in 'mlumr_normal_spfa', line 172, column 11 to column 16)",
-  " (in 'mlumr_normal_spfa', line 172, column 4 to column 57)",
-  " (in 'mlumr_normal_spfa', line 177, column 6 to column 61)",
-  " (in 'mlumr_normal_spfa', line 178, column 6 to column 47)",
-  " (in 'mlumr_normal_spfa', line 176, column 11 to line 179, column 5)",
-  " (in 'mlumr_normal_spfa', line 174, column 6 to column 47)",
-  " (in 'mlumr_normal_spfa', line 175, column 6 to column 50)",
-  " (in 'mlumr_normal_spfa', line 173, column 19 to line 176, column 5)",
-  " (in 'mlumr_normal_spfa', line 173, column 4 to line 179, column 5)",
-  " (in 'mlumr_normal_spfa', line 171, column 26 to line 180, column 3)",
-  " (in 'mlumr_normal_spfa', line 171, column 2 to line 180, column 3)",
+  " (in 'mlumr_normal_spfa', line 141, column 2 to column 24)",
+  " (in 'mlumr_normal_spfa', line 142, column 2 to column 22)",
+  " (in 'mlumr_normal_spfa', line 146, column 2 to column 60)",
+  " (in 'mlumr_normal_spfa', line 147, column 2 to column 29)",
+  " (in 'mlumr_normal_spfa', line 148, column 2 to column 34)",
+  " (in 'mlumr_normal_spfa', line 149, column 2 to column 50)",
+  " (in 'mlumr_normal_spfa', line 151, column 2 to column 48)",
+  " (in 'mlumr_normal_spfa', line 191, column 2 to column 19)",
+  " (in 'mlumr_normal_spfa', line 192, column 2 to column 24)",
+  " (in 'mlumr_normal_spfa', line 194, column 2 to column 21)",
+  " (in 'mlumr_normal_spfa', line 195, column 2 to column 26)",
+  " (in 'mlumr_normal_spfa', line 196, column 2 to column 26)",
+  " (in 'mlumr_normal_spfa', line 197, column 2 to column 31)",
+  " (in 'mlumr_normal_spfa', line 198, column 2 to column 26)",
+  " (in 'mlumr_normal_spfa', line 199, column 2 to column 31)",
+  " (in 'mlumr_normal_spfa', line 200, column 2 to column 31)",
+  " (in 'mlumr_normal_spfa', line 201, column 2 to column 36)",
+  " (in 'mlumr_normal_spfa', line 204, column 2 to column 28)",
+  " (in 'mlumr_normal_spfa', line 205, column 2 to column 33)",
+  " (in 'mlumr_normal_spfa', line 208, column 11 to column 16)",
+  " (in 'mlumr_normal_spfa', line 208, column 4 to column 56)",
+  " (in 'mlumr_normal_spfa', line 209, column 11 to column 16)",
+  " (in 'mlumr_normal_spfa', line 209, column 4 to column 66)",
+  " (in 'mlumr_normal_spfa', line 217, column 6 to column 55)",
+  " (in 'mlumr_normal_spfa', line 218, column 6 to column 65)",
+  " (in 'mlumr_normal_spfa', line 219, column 6 to column 39)",
+  " (in 'mlumr_normal_spfa', line 220, column 6 to column 49)",
+  " (in 'mlumr_normal_spfa', line 221, column 6 to column 39)",
+  " (in 'mlumr_normal_spfa', line 222, column 6 to column 49)",
+  " (in 'mlumr_normal_spfa', line 223, column 6 to column 66)",
+  " (in 'mlumr_normal_spfa', line 216, column 11 to line 224, column 5)",
+  " (in 'mlumr_normal_spfa', line 211, column 6 to column 40)",
+  " (in 'mlumr_normal_spfa', line 212, column 6 to column 50)",
+  " (in 'mlumr_normal_spfa', line 213, column 6 to column 41)",
+  " (in 'mlumr_normal_spfa', line 214, column 6 to column 51)",
+  " (in 'mlumr_normal_spfa', line 215, column 6 to column 55)",
+  " (in 'mlumr_normal_spfa', line 210, column 19 to line 216, column 5)",
+  " (in 'mlumr_normal_spfa', line 210, column 4 to line 224, column 5)",
+  " (in 'mlumr_normal_spfa', line 207, column 2 to line 225, column 3)",
+  " (in 'mlumr_normal_spfa', line 233, column 11 to column 21)",
+  " (in 'mlumr_normal_spfa', line 233, column 4 to column 33)",
+  " (in 'mlumr_normal_spfa', line 234, column 11 to column 21)",
+  " (in 'mlumr_normal_spfa', line 234, column 4 to column 38)",
+  " (in 'mlumr_normal_spfa', line 235, column 11 to column 21)",
+  " (in 'mlumr_normal_spfa', line 235, column 4 to column 31)",
+  " (in 'mlumr_normal_spfa', line 237, column 13 to column 18)",
+  " (in 'mlumr_normal_spfa', line 237, column 6 to column 57)",
+  " (in 'mlumr_normal_spfa', line 238, column 13 to column 18)",
+  " (in 'mlumr_normal_spfa', line 238, column 6 to column 62)",
+  " (in 'mlumr_normal_spfa', line 239, column 6 to column 33)",
+  " (in 'mlumr_normal_spfa', line 244, column 8 to column 49)",
+  " (in 'mlumr_normal_spfa', line 245, column 8 to column 54)",
+  " (in 'mlumr_normal_spfa', line 243, column 13 to line 246, column 7)",
+  " (in 'mlumr_normal_spfa', line 241, column 8 to column 37)",
+  " (in 'mlumr_normal_spfa', line 242, column 8 to column 42)",
+  " (in 'mlumr_normal_spfa', line 240, column 21 to line 243, column 7)",
+  " (in 'mlumr_normal_spfa', line 240, column 6 to line 246, column 7)",
+  " (in 'mlumr_normal_spfa', line 236, column 28 to line 247, column 5)",
+  " (in 'mlumr_normal_spfa', line 236, column 4 to line 247, column 5)",
+  " (in 'mlumr_normal_spfa', line 256, column 6 to column 71)",
+  " (in 'mlumr_normal_spfa', line 257, column 6 to column 81)",
+  " (in 'mlumr_normal_spfa', line 258, column 6 to column 44)",
+  " (in 'mlumr_normal_spfa', line 259, column 6 to column 54)",
+  " (in 'mlumr_normal_spfa', line 260, column 6 to column 44)",
+  " (in 'mlumr_normal_spfa', line 261, column 6 to column 54)",
+  " (in 'mlumr_normal_spfa', line 262, column 6 to column 71)",
+  " (in 'mlumr_normal_spfa', line 255, column 11 to line 263, column 5)",
+  " (in 'mlumr_normal_spfa', line 249, column 6 to column 74)",
+  " (in 'mlumr_normal_spfa', line 250, column 6 to line 251, column 45)",
+  " (in 'mlumr_normal_spfa', line 252, column 6 to column 51)",
+  " (in 'mlumr_normal_spfa', line 253, column 6 to column 61)",
+  " (in 'mlumr_normal_spfa', line 254, column 6 to column 70)",
+  " (in 'mlumr_normal_spfa', line 248, column 19 to line 255, column 5)",
+  " (in 'mlumr_normal_spfa', line 248, column 4 to line 263, column 5)",
+  " (in 'mlumr_normal_spfa', line 232, column 2 to line 264, column 3)",
+  " (in 'mlumr_normal_spfa', line 270, column 11 to column 16)",
+  " (in 'mlumr_normal_spfa', line 270, column 4 to column 42)",
+  " (in 'mlumr_normal_spfa', line 272, column 6 to column 64)",
+  " (in 'mlumr_normal_spfa', line 271, column 4 to line 272, column 64)",
+  " (in 'mlumr_normal_spfa', line 269, column 9 to line 273, column 3)",
+  " (in 'mlumr_normal_spfa', line 268, column 6 to column 67)",
+  " (in 'mlumr_normal_spfa', line 267, column 4 to line 268, column 67)",
+  " (in 'mlumr_normal_spfa', line 266, column 17 to line 269, column 3)",
+  " (in 'mlumr_normal_spfa', line 266, column 2 to line 273, column 3)",
+  " (in 'mlumr_normal_spfa', line 276, column 11 to column 16)",
+  " (in 'mlumr_normal_spfa', line 276, column 4 to column 66)",
+  " (in 'mlumr_normal_spfa', line 281, column 6 to column 61)",
+  " (in 'mlumr_normal_spfa', line 282, column 6 to column 69)",
+  " (in 'mlumr_normal_spfa', line 280, column 11 to line 283, column 5)",
+  " (in 'mlumr_normal_spfa', line 278, column 6 to column 47)",
+  " (in 'mlumr_normal_spfa', line 279, column 6 to column 72)",
+  " (in 'mlumr_normal_spfa', line 277, column 19 to line 280, column 5)",
+  " (in 'mlumr_normal_spfa', line 277, column 4 to line 283, column 5)",
+  " (in 'mlumr_normal_spfa', line 275, column 26 to line 284, column 3)",
+  " (in 'mlumr_normal_spfa', line 275, column 2 to line 284, column 3)",
+  " (in 'mlumr_normal_spfa', line 155, column 2 to line 156, column 71)",
+  " (in 'mlumr_normal_spfa', line 157, column 2 to line 158, column 71)",
+  " (in 'mlumr_normal_spfa', line 159, column 2 to line 160, column 61)",
+  " (in 'mlumr_normal_spfa', line 162, column 2 to line 163, column 62)",
+  " (in 'mlumr_normal_spfa', line 172, column 4 to column 42)",
+  " (in 'mlumr_normal_spfa', line 171, column 9 to line 173, column 3)",
+  " (in 'mlumr_normal_spfa', line 170, column 6 to column 58)",
+  " (in 'mlumr_normal_spfa', line 168, column 6 to column 39)",
+  " (in 'mlumr_normal_spfa', line 167, column 4 to line 170, column 58)",
+  " (in 'mlumr_normal_spfa', line 166, column 17 to line 171, column 3)",
+  " (in 'mlumr_normal_spfa', line 166, column 2 to line 173, column 3)",
+  " (in 'mlumr_normal_spfa', line 177, column 11 to column 16)",
+  " (in 'mlumr_normal_spfa', line 177, column 4 to column 57)",
+  " (in 'mlumr_normal_spfa', line 182, column 6 to column 61)",
+  " (in 'mlumr_normal_spfa', line 183, column 6 to column 47)",
+  " (in 'mlumr_normal_spfa', line 181, column 11 to line 184, column 5)",
+  " (in 'mlumr_normal_spfa', line 179, column 6 to column 47)",
+  " (in 'mlumr_normal_spfa', line 180, column 6 to column 50)",
+  " (in 'mlumr_normal_spfa', line 178, column 19 to line 181, column 5)",
+  " (in 'mlumr_normal_spfa', line 178, column 4 to line 184, column 5)",
+  " (in 'mlumr_normal_spfa', line 176, column 26 to line 185, column 3)",
+  " (in 'mlumr_normal_spfa', line 176, column 2 to line 185, column 3)",
   " (in 'mlumr_normal_spfa', line 74, column 2 to column 21)",
   " (in 'mlumr_normal_spfa', line 75, column 9 to column 14)",
   " (in 'mlumr_normal_spfa', line 75, column 2 to column 22)",
@@ -144,44 +144,46 @@ static constexpr std::array<const char*, 196> locations_array__ =
   " (in 'mlumr_normal_spfa', line 81, column 2 to column 31)",
   " (in 'mlumr_normal_spfa', line 84, column 8 to column 18)",
   " (in 'mlumr_normal_spfa', line 84, column 2 to column 41)",
-  " (in 'mlumr_normal_spfa', line 86, column 2 to column 21)",
-  " (in 'mlumr_normal_spfa', line 87, column 8 to column 18)",
-  " (in 'mlumr_normal_spfa', line 87, column 27 to column 32)",
-  " (in 'mlumr_normal_spfa', line 87, column 34 to column 39)",
-  " (in 'mlumr_normal_spfa', line 87, column 2 to column 47)",
-  " (in 'mlumr_normal_spfa', line 89, column 2 to column 26)",
-  " (in 'mlumr_normal_spfa', line 90, column 2 to column 18)",
-  " (in 'mlumr_normal_spfa', line 91, column 9 to column 14)",
-  " (in 'mlumr_normal_spfa', line 91, column 16 to column 18)",
-  " (in 'mlumr_normal_spfa', line 91, column 2 to column 27)",
+  " (in 'mlumr_normal_spfa', line 89, column 18 to column 28)",
+  " (in 'mlumr_normal_spfa', line 89, column 2 to column 41)",
+  " (in 'mlumr_normal_spfa', line 91, column 2 to column 21)",
   " (in 'mlumr_normal_spfa', line 92, column 8 to column 18)",
   " (in 'mlumr_normal_spfa', line 92, column 27 to column 32)",
-  " (in 'mlumr_normal_spfa', line 92, column 34 to column 36)",
-  " (in 'mlumr_normal_spfa', line 92, column 2 to column 45)",
-  " (in 'mlumr_normal_spfa', line 93, column 9 to column 11)",
-  " (in 'mlumr_normal_spfa', line 93, column 13 to column 15)",
-  " (in 'mlumr_normal_spfa', line 93, column 2 to column 23)",
-  " (in 'mlumr_normal_spfa', line 110, column 0 to column 26)",
-  " (in 'mlumr_normal_spfa', line 111, column 0 to column 33)",
-  " (in 'mlumr_normal_spfa', line 112, column 0 to column 42)",
-  " (in 'mlumr_normal_spfa', line 113, column 0 to column 33)",
-  " (in 'mlumr_normal_spfa', line 115, column 7 to column 12)",
-  " (in 'mlumr_normal_spfa', line 115, column 0 to column 30)",
-  " (in 'mlumr_normal_spfa', line 116, column 16 to column 21)",
-  " (in 'mlumr_normal_spfa', line 116, column 0 to column 37)",
-  " (in 'mlumr_normal_spfa', line 117, column 0 to column 37)",
-  " (in 'mlumr_normal_spfa', line 118, column 0 to column 28)",
-  " (in 'mlumr_normal_spfa', line 128, column 0 to column 26)",
-  " (in 'mlumr_normal_spfa', line 129, column 0 to column 32)",
-  " (in 'mlumr_normal_spfa', line 130, column 0 to column 38)",
-  " (in 'mlumr_normal_spfa', line 131, column 0 to column 29)",
-  " (in 'mlumr_normal_spfa', line 132, column 2 to column 28)",
-  " (in 'mlumr_normal_spfa', line 136, column 9 to column 11)",
+  " (in 'mlumr_normal_spfa', line 92, column 34 to column 39)",
+  " (in 'mlumr_normal_spfa', line 92, column 2 to column 47)",
+  " (in 'mlumr_normal_spfa', line 94, column 2 to column 26)",
+  " (in 'mlumr_normal_spfa', line 95, column 2 to column 18)",
+  " (in 'mlumr_normal_spfa', line 96, column 9 to column 14)",
+  " (in 'mlumr_normal_spfa', line 96, column 16 to column 18)",
+  " (in 'mlumr_normal_spfa', line 96, column 2 to column 27)",
+  " (in 'mlumr_normal_spfa', line 97, column 8 to column 18)",
+  " (in 'mlumr_normal_spfa', line 97, column 27 to column 32)",
+  " (in 'mlumr_normal_spfa', line 97, column 34 to column 36)",
+  " (in 'mlumr_normal_spfa', line 97, column 2 to column 45)",
+  " (in 'mlumr_normal_spfa', line 98, column 9 to column 11)",
+  " (in 'mlumr_normal_spfa', line 98, column 13 to column 15)",
+  " (in 'mlumr_normal_spfa', line 98, column 2 to column 23)",
+  " (in 'mlumr_normal_spfa', line 115, column 0 to column 26)",
+  " (in 'mlumr_normal_spfa', line 116, column 0 to column 33)",
+  " (in 'mlumr_normal_spfa', line 117, column 0 to column 42)",
+  " (in 'mlumr_normal_spfa', line 118, column 0 to column 33)",
+  " (in 'mlumr_normal_spfa', line 120, column 7 to column 12)",
+  " (in 'mlumr_normal_spfa', line 120, column 0 to column 30)",
+  " (in 'mlumr_normal_spfa', line 121, column 16 to column 21)",
+  " (in 'mlumr_normal_spfa', line 121, column 0 to column 37)",
+  " (in 'mlumr_normal_spfa', line 122, column 0 to column 37)",
+  " (in 'mlumr_normal_spfa', line 123, column 0 to column 28)",
+  " (in 'mlumr_normal_spfa', line 133, column 0 to column 26)",
+  " (in 'mlumr_normal_spfa', line 134, column 0 to column 32)",
+  " (in 'mlumr_normal_spfa', line 135, column 0 to column 38)",
+  " (in 'mlumr_normal_spfa', line 136, column 0 to column 29)",
+  " (in 'mlumr_normal_spfa', line 137, column 2 to column 28)",
   " (in 'mlumr_normal_spfa', line 141, column 9 to column 11)",
-  " (in 'mlumr_normal_spfa', line 144, column 9 to column 14)",
-  " (in 'mlumr_normal_spfa', line 146, column 9 to column 14)",
-  " (in 'mlumr_normal_spfa', line 199, column 9 to column 14)",
-  " (in 'mlumr_normal_spfa', line 200, column 9 to column 19)",
+  " (in 'mlumr_normal_spfa', line 146, column 9 to column 11)",
+  " (in 'mlumr_normal_spfa', line 149, column 9 to column 14)",
+  " (in 'mlumr_normal_spfa', line 151, column 9 to column 14)",
+  " (in 'mlumr_normal_spfa', line 204, column 9 to column 14)",
+  " (in 'mlumr_normal_spfa', line 205, column 9 to column 19)",
   " (in 'mlumr_normal_spfa', line 24, column 7 to column 54)",
   " (in 'mlumr_normal_spfa', line 23, column 17 to column 57)",
   " (in 'mlumr_normal_spfa', line 23, column 2 to line 24, column 54)",
@@ -309,12 +311,12 @@ log_prior_scalar(const T0__& x, const T1__& location, const T2__& scale,
   // suppress unused var warning
   (void) DUMMY_VAR__;
   try {
-    current_statement__ = 170;
+    current_statement__ = 172;
     if (stan::math::logical_eq(dist, 0)) {
-      current_statement__ = 169;
+      current_statement__ = 171;
       return stan::math::normal_lpdf<false>(x, location, scale);
     } else {
-      current_statement__ = 168;
+      current_statement__ = 170;
       return stan::math::student_t_lpdf<false>(x, df, location, scale);
     }
   } catch (const std::exception& e) {
@@ -354,12 +356,12 @@ log_prior_vector(const T0__& x_arg__, const T1__& location_arg__, const T2__&
   // suppress unused var warning
   (void) DUMMY_VAR__;
   try {
-    current_statement__ = 174;
+    current_statement__ = 176;
     if (stan::math::logical_eq(dist, 0)) {
-      current_statement__ = 173;
+      current_statement__ = 175;
       return stan::math::normal_lpdf<false>(x, location, scale);
     } else {
-      current_statement__ = 172;
+      current_statement__ = 174;
       return stan::math::student_t_lpdf<false>(x, df, location, scale);
     }
   } catch (const std::exception& e) {
@@ -392,17 +394,17 @@ log_prior_sigma(const T0__& sigma, const T1__& location, const T2__& scale,
   // suppress unused var warning
   (void) DUMMY_VAR__;
   try {
-    current_statement__ = 180;
+    current_statement__ = 182;
     if (stan::math::logical_eq(dist, 0)) {
-      current_statement__ = 179;
+      current_statement__ = 181;
       return stan::math::normal_lpdf<false>(sigma, location, scale);
     } else {
-      current_statement__ = 178;
+      current_statement__ = 180;
       if (stan::math::logical_eq(dist, 1)) {
-        current_statement__ = 177;
+        current_statement__ = 179;
         return stan::math::student_t_lpdf<false>(sigma, df, location, scale);
       } else {
-        current_statement__ = 176;
+        current_statement__ = 178;
         return stan::math::exponential_lpdf<false>(sigma,
                  stan::math::inv(scale));
       }
@@ -433,12 +435,12 @@ log_prior_std_vector(const T0__& z_arg__, const T1__& dist, const T2__& df,
   // suppress unused var warning
   (void) DUMMY_VAR__;
   try {
-    current_statement__ = 184;
+    current_statement__ = 186;
     if (stan::math::logical_eq(dist, 0)) {
-      current_statement__ = 183;
+      current_statement__ = 185;
       return stan::math::std_normal_lpdf<false>(z);
     } else {
-      current_statement__ = 182;
+      current_statement__ = 184;
       return stan::math::student_t_lpdf<false>(z, df, static_cast<double>(0),
                static_cast<double>(1));
     }
@@ -464,7 +466,7 @@ log_mean_exp_vec(const T0__& x_arg__, std::ostream* pstream__) {
   // suppress unused var warning
   (void) DUMMY_VAR__;
   try {
-    current_statement__ = 186;
+    current_statement__ = 188;
     return (stan::math::log_sum_exp(x) -
            stan::math::log(stan::math::num_elements(x)));
   } catch (const std::exception& e) {
@@ -494,7 +496,7 @@ log_weighted_mean_exp_vec(const T0__& log_x_arg__, const T1__& weights_arg__,
   // suppress unused var warning
   (void) DUMMY_VAR__;
   try {
-    current_statement__ = 188;
+    current_statement__ = 190;
     return (stan::math::log_sum_exp(
               stan::math::add(stan::math::log(weights), log_x))
            - stan::math::log_sum_exp(stan::math::log(weights)));
@@ -521,18 +523,18 @@ exp_difference(const T0__& log_x, const T1__& log_y, std::ostream* pstream__) {
   // suppress unused var warning
   (void) DUMMY_VAR__;
   try {
-    current_statement__ = 194;
+    current_statement__ = 196;
     if (stan::math::logical_eq(log_x, log_y)) {
-      current_statement__ = 193;
+      current_statement__ = 195;
       return stan::math::promote_scalar<local_scalar_t__>(0);
     } else {
-      current_statement__ = 192;
+      current_statement__ = 194;
       if (stan::math::logical_gt(log_x, log_y)) {
-        current_statement__ = 191;
+        current_statement__ = 193;
         return stan::math::exp((log_x +
                  stan::math::log1m_exp((log_y - log_x))));
       } else {
-        current_statement__ = 190;
+        current_statement__ = 192;
         return -(stan::math::exp((log_y +
                    stan::math::log1m_exp((log_x - log_y)))));
       }
@@ -551,6 +553,7 @@ private:
   int n_agd_rows;
   std::vector<double> y_agd;
   std::vector<double> se_agd;
+  Eigen::Matrix<double,-1,1> agd_weight_data__;
   int n_int;
   std::vector<Eigen::Matrix<double,-1,-1>> X_int;
   int qr;
@@ -573,6 +576,7 @@ private:
   int link;
   Eigen::Map<Eigen::Matrix<double,-1,1>> y_ipd{nullptr, 0};
   Eigen::Map<Eigen::Matrix<double,-1,-1>> X_ipd{nullptr, 0, 0};
+  Eigen::Map<Eigen::Matrix<double,-1,1>> agd_weight{nullptr, 0};
   Eigen::Map<Eigen::Matrix<double,-1,-1>> Xq_ipd{nullptr, 0, 0};
   Eigen::Map<Eigen::Matrix<double,-1,-1>> R_inv{nullptr, 0, 0};
   Eigen::Map<Eigen::Matrix<double,-1,1>> prior_beta_mean{nullptr, 0};
@@ -694,21 +698,46 @@ public:
       current_statement__ = 129;
       stan::math::check_greater_or_equal(function__, "se_agd", se_agd, 0);
       current_statement__ = 130;
+      stan::math::validate_non_negative_index("agd_weight", "n_agd_rows",
+        n_agd_rows);
+      current_statement__ = 131;
+      context__.validate_dims("data initialization", "agd_weight", "double",
+        std::vector<size_t>{static_cast<size_t>(n_agd_rows)});
+      agd_weight_data__ = Eigen::Matrix<double,-1,1>::Constant(n_agd_rows,
+                            std::numeric_limits<double>::quiet_NaN());
+      new (&agd_weight)
+        Eigen::Map<Eigen::Matrix<double,-1,1>>(agd_weight_data__.data(),
+        n_agd_rows);
+      {
+        std::vector<local_scalar_t__> agd_weight_flat__;
+        current_statement__ = 131;
+        agd_weight_flat__ = context__.vals_r("agd_weight");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= n_agd_rows; ++sym1__) {
+          stan::model::assign(agd_weight, agd_weight_flat__[(pos__ - 1)],
+            "assigning variable agd_weight", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      current_statement__ = 131;
+      stan::math::check_greater_or_equal(function__, "agd_weight",
+        agd_weight, 0);
+      current_statement__ = 132;
       context__.validate_dims("data initialization", "n_int", "int",
         std::vector<size_t>{});
       n_int = std::numeric_limits<int>::min();
-      current_statement__ = 130;
+      current_statement__ = 132;
       n_int = context__.vals_i("n_int")[(1 - 1)];
-      current_statement__ = 130;
+      current_statement__ = 132;
       stan::math::check_greater_or_equal(function__, "n_int", n_int, 1);
-      current_statement__ = 131;
+      current_statement__ = 133;
       stan::math::validate_non_negative_index("X_int", "n_agd_rows",
         n_agd_rows);
-      current_statement__ = 132;
-      stan::math::validate_non_negative_index("X_int", "n_int", n_int);
-      current_statement__ = 133;
-      stan::math::validate_non_negative_index("X_int", "n_cov", n_cov);
       current_statement__ = 134;
+      stan::math::validate_non_negative_index("X_int", "n_int", n_int);
+      current_statement__ = 135;
+      stan::math::validate_non_negative_index("X_int", "n_cov", n_cov);
+      current_statement__ = 136;
       context__.validate_dims("data initialization", "X_int", "double",
         std::vector<size_t>{static_cast<size_t>(n_agd_rows),
           static_cast<size_t>(n_int), static_cast<size_t>(n_cov)});
@@ -717,7 +746,7 @@ public:
                   std::numeric_limits<double>::quiet_NaN()));
       {
         std::vector<local_scalar_t__> X_int_flat__;
-        current_statement__ = 134;
+        current_statement__ = 136;
         X_int_flat__ = context__.vals_r("X_int");
         pos__ = 1;
         for (int sym1__ = 1; sym1__ <= n_cov; ++sym1__) {
@@ -732,29 +761,29 @@ public:
           }
         }
       }
-      current_statement__ = 135;
+      current_statement__ = 137;
       context__.validate_dims("data initialization", "qr", "int",
         std::vector<size_t>{});
       qr = std::numeric_limits<int>::min();
-      current_statement__ = 135;
+      current_statement__ = 137;
       qr = context__.vals_i("qr")[(1 - 1)];
-      current_statement__ = 135;
+      current_statement__ = 137;
       stan::math::check_greater_or_equal(function__, "qr", qr, 0);
-      current_statement__ = 135;
+      current_statement__ = 137;
       stan::math::check_less_or_equal(function__, "qr", qr, 1);
-      current_statement__ = 136;
+      current_statement__ = 138;
       context__.validate_dims("data initialization", "nB", "int",
         std::vector<size_t>{});
       nB = std::numeric_limits<int>::min();
-      current_statement__ = 136;
-      nB = context__.vals_i("nB")[(1 - 1)];
-      current_statement__ = 136;
-      stan::math::check_greater_or_equal(function__, "nB", nB, 1);
-      current_statement__ = 137;
-      stan::math::validate_non_negative_index("Xq_ipd", "n_ipd", n_ipd);
       current_statement__ = 138;
-      stan::math::validate_non_negative_index("Xq_ipd", "nB", nB);
+      nB = context__.vals_i("nB")[(1 - 1)];
+      current_statement__ = 138;
+      stan::math::check_greater_or_equal(function__, "nB", nB, 1);
       current_statement__ = 139;
+      stan::math::validate_non_negative_index("Xq_ipd", "n_ipd", n_ipd);
+      current_statement__ = 140;
+      stan::math::validate_non_negative_index("Xq_ipd", "nB", nB);
+      current_statement__ = 141;
       context__.validate_dims("data initialization", "Xq_ipd", "double",
         std::vector<size_t>{static_cast<size_t>(n_ipd),
           static_cast<size_t>(nB)});
@@ -765,7 +794,7 @@ public:
         nB);
       {
         std::vector<local_scalar_t__> Xq_ipd_flat__;
-        current_statement__ = 139;
+        current_statement__ = 141;
         Xq_ipd_flat__ = context__.vals_r("Xq_ipd");
         pos__ = 1;
         for (int sym1__ = 1; sym1__ <= nB; ++sym1__) {
@@ -777,14 +806,14 @@ public:
           }
         }
       }
-      current_statement__ = 140;
+      current_statement__ = 142;
       stan::math::validate_non_negative_index("Xq_int", "n_agd_rows",
         n_agd_rows);
-      current_statement__ = 141;
-      stan::math::validate_non_negative_index("Xq_int", "n_int", n_int);
-      current_statement__ = 142;
-      stan::math::validate_non_negative_index("Xq_int", "nB", nB);
       current_statement__ = 143;
+      stan::math::validate_non_negative_index("Xq_int", "n_int", n_int);
+      current_statement__ = 144;
+      stan::math::validate_non_negative_index("Xq_int", "nB", nB);
+      current_statement__ = 145;
       context__.validate_dims("data initialization", "Xq_int", "double",
         std::vector<size_t>{static_cast<size_t>(n_agd_rows),
           static_cast<size_t>(n_int), static_cast<size_t>(nB)});
@@ -793,7 +822,7 @@ public:
                    std::numeric_limits<double>::quiet_NaN()));
       {
         std::vector<local_scalar_t__> Xq_int_flat__;
-        current_statement__ = 143;
+        current_statement__ = 145;
         Xq_int_flat__ = context__.vals_r("Xq_int");
         pos__ = 1;
         for (int sym1__ = 1; sym1__ <= nB; ++sym1__) {
@@ -808,11 +837,11 @@ public:
           }
         }
       }
-      current_statement__ = 144;
-      stan::math::validate_non_negative_index("R_inv", "nB", nB);
-      current_statement__ = 145;
-      stan::math::validate_non_negative_index("R_inv", "nB", nB);
       current_statement__ = 146;
+      stan::math::validate_non_negative_index("R_inv", "nB", nB);
+      current_statement__ = 147;
+      stan::math::validate_non_negative_index("R_inv", "nB", nB);
+      current_statement__ = 148;
       context__.validate_dims("data initialization", "R_inv", "double",
         std::vector<size_t>{static_cast<size_t>(nB), static_cast<size_t>(nB)});
       R_inv_data__ = Eigen::Matrix<double,-1,-1>::Constant(nB, nB,
@@ -821,7 +850,7 @@ public:
         Eigen::Map<Eigen::Matrix<double,-1,-1>>(R_inv_data__.data(), nB, nB);
       {
         std::vector<local_scalar_t__> R_inv_flat__;
-        current_statement__ = 146;
+        current_statement__ = 148;
         R_inv_flat__ = context__.vals_r("R_inv");
         pos__ = 1;
         for (int sym1__ = 1; sym1__ <= nB; ++sym1__) {
@@ -833,48 +862,48 @@ public:
           }
         }
       }
-      current_statement__ = 147;
+      current_statement__ = 149;
       context__.validate_dims("data initialization", "prior_intercept_mean",
         "double", std::vector<size_t>{});
       prior_intercept_mean = std::numeric_limits<double>::quiet_NaN();
-      current_statement__ = 147;
+      current_statement__ = 149;
       prior_intercept_mean = context__.vals_r("prior_intercept_mean")[(1 -
         1)];
-      current_statement__ = 148;
+      current_statement__ = 150;
       context__.validate_dims("data initialization", "prior_intercept_sd",
         "double", std::vector<size_t>{});
       prior_intercept_sd = std::numeric_limits<double>::quiet_NaN();
-      current_statement__ = 148;
+      current_statement__ = 150;
       prior_intercept_sd = context__.vals_r("prior_intercept_sd")[(1 - 1)];
-      current_statement__ = 148;
+      current_statement__ = 150;
       stan::math::check_greater_or_equal(function__, "prior_intercept_sd",
         prior_intercept_sd, 0);
-      current_statement__ = 149;
+      current_statement__ = 151;
       context__.validate_dims("data initialization", "prior_intercept_dist",
         "int", std::vector<size_t>{});
       prior_intercept_dist = std::numeric_limits<int>::min();
-      current_statement__ = 149;
+      current_statement__ = 151;
       prior_intercept_dist = context__.vals_i("prior_intercept_dist")[(1 -
         1)];
-      current_statement__ = 149;
+      current_statement__ = 151;
       stan::math::check_greater_or_equal(function__, "prior_intercept_dist",
         prior_intercept_dist, 0);
-      current_statement__ = 149;
+      current_statement__ = 151;
       stan::math::check_less_or_equal(function__, "prior_intercept_dist",
         prior_intercept_dist, 1);
-      current_statement__ = 150;
+      current_statement__ = 152;
       context__.validate_dims("data initialization", "prior_intercept_df",
         "double", std::vector<size_t>{});
       prior_intercept_df = std::numeric_limits<double>::quiet_NaN();
-      current_statement__ = 150;
+      current_statement__ = 152;
       prior_intercept_df = context__.vals_r("prior_intercept_df")[(1 - 1)];
-      current_statement__ = 150;
+      current_statement__ = 152;
       stan::math::check_greater_or_equal(function__, "prior_intercept_df",
         prior_intercept_df, 0);
-      current_statement__ = 151;
+      current_statement__ = 153;
       stan::math::validate_non_negative_index("prior_beta_mean", "n_cov",
         n_cov);
-      current_statement__ = 152;
+      current_statement__ = 154;
       context__.validate_dims("data initialization", "prior_beta_mean",
         "double", std::vector<size_t>{static_cast<size_t>(n_cov)});
       prior_beta_mean_data__ = Eigen::Matrix<double,-1,1>::Constant(n_cov,
@@ -884,7 +913,7 @@ public:
         n_cov);
       {
         std::vector<local_scalar_t__> prior_beta_mean_flat__;
-        current_statement__ = 152;
+        current_statement__ = 154;
         prior_beta_mean_flat__ = context__.vals_r("prior_beta_mean");
         pos__ = 1;
         for (int sym1__ = 1; sym1__ <= n_cov; ++sym1__) {
@@ -894,9 +923,9 @@ public:
           pos__ = (pos__ + 1);
         }
       }
-      current_statement__ = 153;
+      current_statement__ = 155;
       stan::math::validate_non_negative_index("prior_beta_sd", "n_cov", n_cov);
-      current_statement__ = 154;
+      current_statement__ = 156;
       context__.validate_dims("data initialization", "prior_beta_sd",
         "double", std::vector<size_t>{static_cast<size_t>(n_cov)});
       prior_beta_sd_data__ = Eigen::Matrix<double,-1,1>::Constant(n_cov,
@@ -906,7 +935,7 @@ public:
         n_cov);
       {
         std::vector<local_scalar_t__> prior_beta_sd_flat__;
-        current_statement__ = 154;
+        current_statement__ = 156;
         prior_beta_sd_flat__ = context__.vals_r("prior_beta_sd");
         pos__ = 1;
         for (int sym1__ = 1; sym1__ <= n_cov; ++sym1__) {
@@ -916,88 +945,88 @@ public:
           pos__ = (pos__ + 1);
         }
       }
-      current_statement__ = 154;
+      current_statement__ = 156;
       stan::math::check_greater_or_equal(function__, "prior_beta_sd",
         prior_beta_sd, 0);
-      current_statement__ = 155;
+      current_statement__ = 157;
       context__.validate_dims("data initialization", "prior_beta_dist",
         "int", std::vector<size_t>{});
       prior_beta_dist = std::numeric_limits<int>::min();
-      current_statement__ = 155;
+      current_statement__ = 157;
       prior_beta_dist = context__.vals_i("prior_beta_dist")[(1 - 1)];
-      current_statement__ = 155;
+      current_statement__ = 157;
       stan::math::check_greater_or_equal(function__, "prior_beta_dist",
         prior_beta_dist, 0);
-      current_statement__ = 155;
+      current_statement__ = 157;
       stan::math::check_less_or_equal(function__, "prior_beta_dist",
         prior_beta_dist, 1);
-      current_statement__ = 156;
+      current_statement__ = 158;
       context__.validate_dims("data initialization", "prior_beta_df",
         "double", std::vector<size_t>{});
       prior_beta_df = std::numeric_limits<double>::quiet_NaN();
-      current_statement__ = 156;
+      current_statement__ = 158;
       prior_beta_df = context__.vals_r("prior_beta_df")[(1 - 1)];
-      current_statement__ = 156;
+      current_statement__ = 158;
       stan::math::check_greater_or_equal(function__, "prior_beta_df",
         prior_beta_df, 0);
-      current_statement__ = 157;
+      current_statement__ = 159;
       context__.validate_dims("data initialization", "prior_sigma_location",
         "double", std::vector<size_t>{});
       prior_sigma_location = std::numeric_limits<double>::quiet_NaN();
-      current_statement__ = 157;
+      current_statement__ = 159;
       prior_sigma_location = context__.vals_r("prior_sigma_location")[(1 -
         1)];
-      current_statement__ = 158;
+      current_statement__ = 160;
       context__.validate_dims("data initialization", "prior_sigma_scale",
         "double", std::vector<size_t>{});
       prior_sigma_scale = std::numeric_limits<double>::quiet_NaN();
-      current_statement__ = 158;
+      current_statement__ = 160;
       prior_sigma_scale = context__.vals_r("prior_sigma_scale")[(1 - 1)];
-      current_statement__ = 158;
+      current_statement__ = 160;
       stan::math::check_greater_or_equal(function__, "prior_sigma_scale",
         prior_sigma_scale, 0);
-      current_statement__ = 159;
+      current_statement__ = 161;
       context__.validate_dims("data initialization", "prior_sigma_dist",
         "int", std::vector<size_t>{});
       prior_sigma_dist = std::numeric_limits<int>::min();
-      current_statement__ = 159;
+      current_statement__ = 161;
       prior_sigma_dist = context__.vals_i("prior_sigma_dist")[(1 - 1)];
-      current_statement__ = 159;
+      current_statement__ = 161;
       stan::math::check_greater_or_equal(function__, "prior_sigma_dist",
         prior_sigma_dist, 0);
-      current_statement__ = 159;
+      current_statement__ = 161;
       stan::math::check_less_or_equal(function__, "prior_sigma_dist",
         prior_sigma_dist, 2);
-      current_statement__ = 160;
+      current_statement__ = 162;
       context__.validate_dims("data initialization", "prior_sigma_df",
         "double", std::vector<size_t>{});
       prior_sigma_df = std::numeric_limits<double>::quiet_NaN();
-      current_statement__ = 160;
+      current_statement__ = 162;
       prior_sigma_df = context__.vals_r("prior_sigma_df")[(1 - 1)];
-      current_statement__ = 160;
+      current_statement__ = 162;
       stan::math::check_greater_or_equal(function__, "prior_sigma_df",
         prior_sigma_df, 0);
-      current_statement__ = 161;
+      current_statement__ = 163;
       context__.validate_dims("data initialization", "link", "int",
         std::vector<size_t>{});
       link = std::numeric_limits<int>::min();
-      current_statement__ = 161;
-      link = context__.vals_i("link")[(1 - 1)];
-      current_statement__ = 161;
-      stan::math::check_greater_or_equal(function__, "link", link, 1);
-      current_statement__ = 161;
-      stan::math::check_less_or_equal(function__, "link", link, 2);
-      current_statement__ = 162;
-      stan::math::validate_non_negative_index("beta_tilde", "nB", nB);
       current_statement__ = 163;
-      stan::math::validate_non_negative_index("allbeta", "nB", nB);
+      link = context__.vals_i("link")[(1 - 1)];
+      current_statement__ = 163;
+      stan::math::check_greater_or_equal(function__, "link", link, 1);
+      current_statement__ = 163;
+      stan::math::check_less_or_equal(function__, "link", link, 2);
       current_statement__ = 164;
-      stan::math::validate_non_negative_index("beta", "n_cov", n_cov);
+      stan::math::validate_non_negative_index("beta_tilde", "nB", nB);
       current_statement__ = 165;
-      stan::math::validate_non_negative_index("theta_ipd", "n_ipd", n_ipd);
+      stan::math::validate_non_negative_index("allbeta", "nB", nB);
       current_statement__ = 166;
-      stan::math::validate_non_negative_index("log_lik_ipd", "n_ipd", n_ipd);
+      stan::math::validate_non_negative_index("beta", "n_cov", n_cov);
       current_statement__ = 167;
+      stan::math::validate_non_negative_index("theta_ipd", "n_ipd", n_ipd);
+      current_statement__ = 168;
+      stan::math::validate_non_negative_index("log_lik_ipd", "n_ipd", n_ipd);
+      current_statement__ = 169;
       stan::math::validate_non_negative_index("log_lik_agd", "n_agd_rows",
         n_agd_rows);
     } catch (const std::exception& e) {
@@ -1481,7 +1510,9 @@ public:
                 stan::model::rvalue(X_int, "X_int", stan::model::index_uni(k)),
                 beta)), "assigning variable y_cmp_k");
           current_statement__ = 50;
-          stan::model::assign(weights, 1, "assigning variable weights",
+          stan::model::assign(weights,
+            stan::model::rvalue(agd_weight, "agd_weight",
+              stan::model::index_uni(k)), "assigning variable weights",
             stan::model::index_uni(k));
           current_statement__ = 57;
           if (stan::math::logical_eq(link, 1)) {

--- a/tests/testthat/test-centering-invariance.R
+++ b/tests/testthat/test-centering-invariance.R
@@ -61,10 +61,7 @@ test_that("weights fall back to equal when no usable field is present", {
 })
 
 test_that("each family reads its own comparator weight field", {
-  # normal is absent here on purpose: it has no comparator weight field yet, so
-  # it falls back to equal weights and is not split-invariant. It joins this
-  # loop with the change that gives it one.
-  for (fam in c("binomial", "poisson")) {
+  for (fam in c("binomial", "normal", "poisson")) {
     field <- mlumr:::get_family_config(fam)$comp_weight_field
     sd <- make_sd(100, 0, agd_means = c(10, 10), agd_weights = c(30, 70),
                   field = field)


### PR DESCRIPTION
# Summary

The normal family combined several aggregate rows by **inverse variance**, in
the Stan models, in `naive()`, and in `stc()`. That average estimates a common
mean efficiently, but it is not the comparator population's mean. The population
mean is the size-weighted mixture of its strata, which is what the binomial and
Poisson families already target and what the reported effect claims to be.

The practical consequence is that the estimand moved with the tabulation. One
comparator population reported as a single row and the same population reported
as two subgroup rows gave different answers:

| tabulation | reported comparator mean |
|---|---|
| one row, n = 200 | 1.000 |
| two strata, 150 at 0.8 and 50 at 1.6, size-weighted | **1.000** |
| the same two strata, inverse-variance weighted | 1.012 |

Because strata cannot be combined without knowing how large they are,
`set_agd()` now **requires `outcome_n`** for more than one normal aggregate row
rather than silently falling back. Single-row data is unchanged and still does
not need it.

## Type of Change

- [x] Methodological/statistical change

## Statistical or User-Facing Impact

Multi-row normal aggregate data changes answer, and multi-row normal `set_agd()`
calls without `outcome_n` now error instead of running. Single-row aggregate
data, and the binomial and Poisson families, are unaffected.

The Stan models take the weights as `agd_weight`, kept deliberately separate
from the likelihood's own `1/se^2` precision weighting, which is a different
thing serving a different purpose: precision weighting says how much each row
constrains the parameters, population weighting says which population the
estimand refers to.

## Knock-on

The normal family now has a comparator weight field, so it joins the
covariate-centering invariance check: its center no longer moves when one
subgroup is split into two equivalent rows. That test previously excluded normal
with a comment naming this change; the exclusion is removed.

## Verification

```text
pure-R suite (NOT_CRAN=false)  -> pass 595  fail 0  err 0
one row vs two strata          -> table above
single-row set_agd() unchanged -> still accepted without outcome_n
multi-row without outcome_n    -> rejected
lintr on changed R files       -> 0 lints
```

## Documentation

- [ ] README updated if needed (no change needed)
- [x] Help pages or roxygen updated if needed
- [ ] Vignettes updated if needed (documentation pull request)
- [x] NEWS.md updated for user-facing changes

## Checklist

- [x] The change is focused and reviewable
- [x] Relevant tests pass
- [x] No local build artifacts, `.Rcheck` output, tarballs, or caches are committed
- [x] The pull request follows the Code of Conduct


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Updates**
  - Continuous normal-outcome analyses with multiple aggregate-data rows now use sample-size weighting to estimate comparator populations.
  - `naive()` and `stc()` apply consistent population-size weighting, with equal-row weighting when valid sample sizes are unavailable.
  - Multiple normal-family aggregate rows require `outcome_n`, with a clear validation message when it is missing.
  - Single-row aggregate-data behavior remains unchanged.
  - Comparator predictions now consistently reflect the specified population weights.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->