### PR TITLE
Isolate the prior sweep, rescale autoscaled locations, honor verbose

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -56,6 +56,27 @@
   stops with a validation error naming the argument it actually received. Call
   `mlumr()` with named arguments.
 
+* **`prior_sensitivity()` varies the prior and nothing else.** Every
+  model-defining setting is taken from the original fit and replayed: family,
+  link, the design-matrix controls (`center`, `qr`), the integration points, and
+  the engine and sampler settings. `...` may no longer override any of them, so
+  movement across the sweep is attributable to the prior alone.
+
+* **`verbose = FALSE` now silences the sampler banner too.** cmdstanr writes its
+  "Running MCMC with N chains / Chain k finished in ..." lines to stdout rather
+  than through the condition system, so neither `refresh = 0` nor
+  `suppressMessages()` suppressed them: roughly fifteen lines per fit, which
+  buries the output of any loop over more than a handful of models. `mlumr()`
+  now passes `verbose` through to the backend, and an explicit `show_messages`
+  or `show_exceptions` in `...` still wins.
+
+* **`prior_normal(autoscale = TRUE)` rescales the prior location as well as its
+  scale.** Autoscaling states a prior on the coefficient of a covariate measured
+  in standard-deviation units, so recovering it on the original scale divides
+  both the location and the scale by that covariate's SD. Only the scale was
+  divided before, which left a nonzero prior mean attached to the wrong
+  covariate scale. The default `mean = 0` is unaffected, since `0 / sd` is `0`.
+
 * **`check_integration()` compares correlations on one scale.** The realized
   integration-point correlation was always measured with Pearson while the
   target, when derived from the IPD, defaults to Spearman. The method that

--- a/R/backend_cmdstanr.R
+++ b/R/backend_cmdstanr.R
@@ -1,7 +1,8 @@
 #' Fit a Stan model using cmdstanr
 #' @keywords internal
 fit_cmdstanr <- function(model_name, stan_data, chains, iter, warmup,
-                         seed, adapt_delta, max_treedepth, refresh, ...) {
+                         seed, adapt_delta, max_treedepth, refresh,
+                         verbose = TRUE, ...) {
 
   if (!requireNamespace("cmdstanr", quietly = TRUE)) {
     stop("cmdstanr is required but not installed. Run mlumr_engine('cmdstanr') to set up.",
@@ -33,6 +34,19 @@ fit_cmdstanr <- function(model_name, stan_data, chains, iter, warmup,
   if (!"parallel_chains" %in% names(dots)) {
     dots$parallel_chains <- min(chains,
                                 max(1L, as.integer(getOption("mc.cores", 1L))))
+  }
+
+  # cmdstanr writes its "Running MCMC with N chains / Chain k finished in ..."
+  # banner to STDOUT, not through the condition system, so `refresh = 0` does
+  # not stop it and neither does suppressMessages(). That is roughly fifteen
+  # lines per fit, which buries anything real in a loop over many models.
+  # `verbose` is the argument a caller already reaches for, so honor it here
+  # too, while leaving an explicit `show_messages` / `show_exceptions` in `...`
+  # to win. `show_exceptions` was added to cmdstanr later than `show_messages`,
+  # so ask the method what it accepts rather than assuming a version.
+  sample_formals <- names(formals(mod$sample))
+  for (nm in intersect(c("show_messages", "show_exceptions"), sample_formals)) {
+    if (!nm %in% names(dots)) dots[[nm]] <- isTRUE(verbose)
   }
 
   sample_args <- c(

--- a/R/mlumr.R
+++ b/R/mlumr.R
@@ -245,6 +245,7 @@ mlumr <- function(data,
     adapt_delta = adapt_delta,
     max_treedepth = max_treedepth,
     refresh = refresh,
+    verbose = verbose,
     ...
   )
 
@@ -651,10 +652,11 @@ mlumr <- function(data,
 #' @keywords internal
 .mlumr_fit_backend <- function(engine, model_name, stan_data, chains, iter,
                                warmup, seed, adapt_delta, max_treedepth,
-                               refresh, ...) {
+                               refresh, verbose = TRUE, ...) {
   if (engine == "cmdstanr") {
     fit_cmdstanr(model_name, stan_data, chains, iter, warmup,
-                 seed, adapt_delta, max_treedepth, refresh, ...)
+                 seed, adapt_delta, max_treedepth, refresh,
+                 verbose = verbose, ...)
   } else {
     fit_rstan(model_name, stan_data, chains, iter, warmup,
               seed, adapt_delta, max_treedepth, refresh, ...)

--- a/R/prior_sensitivity.R
+++ b/R/prior_sensitivity.R
@@ -76,6 +76,32 @@ prior_sensitivity <- function(fit,
   }
 
   # Inherit the original sampling args unless overridden by ...
+  # `...` is forwarded to each refit, so it must not carry anything that defines
+  # the model. Sampler and backend controls (chains, iter, adapt_delta, engine)
+  # are still allowed through.
+  dots <- list(...)
+  if (length(dots)) {
+    if (is.null(names(dots)) || any(!nzchar(names(dots)))) {
+      stop("All `...` arguments to prior_sensitivity() must be named.",
+           call. = FALSE)
+    }
+    # Everything that defines the model rather than the sampler. Overriding any
+    # of these would vary a second factor alongside the prior scale, so the
+    # movement in the output could no longer be attributed to the prior.
+    protected <- c("data", "model", "link", "prior_beta",
+                   "prior_intercept", "prior_sigma", "center", "qr")
+    clash <- intersect(names(dots), protected)
+    if (length(clash)) {
+      msg <- paste0(
+        "`...` cannot override the scenario-defining argument(s): %s. ",
+        "prior_sensitivity() sweeps `prior_beta` itself and reuses every other ",
+        "setting from the original fit so the sweep varies one factor only; ",
+        "pass only sampler or backend controls."
+      )
+      stop(sprintf(msg, paste(clash, collapse = ", ")), call. = FALSE)
+    }
+  }
+
   sa <- fit$sampling_args %||% list()
   # Design-matrix controls. A fit made with `center = FALSE` or `qr = TRUE` is a
   # different parameterization, so replaying the defaults here would vary the

--- a/R/priors.R
+++ b/R/priors.R
@@ -433,7 +433,13 @@ stan_prior_fields_beta <- function(prior, n_cov, sd_x = NULL,
         paste(bad, collapse = ", ")
       ), call. = FALSE)
     }
+    # Autoscaling states a prior on the coefficient of a covariate measured in
+    # SD units, so recovering it on the original scale divides both the location
+    # and the scale by that covariate's SD. Dividing only the scale would leave
+    # a nonzero prior mean attached to the wrong covariate scale. The default
+    # mean = 0 is unaffected, since 0 / sd is 0.
     sd_x_safe <- ifelse(sd_x > 0, sd_x, 1)
+    means <- ifelse(autos, means / sd_x_safe, means)
     sds <- ifelse(autos, sds / sd_x_safe, sds)
   }
 

--- a/man/dot-mlumr_fit_backend.Rd
+++ b/man/dot-mlumr_fit_backend.Rd
@@ -15,6 +15,7 @@
   adapt_delta,
   max_treedepth,
   refresh,
+  verbose = TRUE,
   ...
 )
 }

--- a/man/fit_cmdstanr.Rd
+++ b/man/fit_cmdstanr.Rd
@@ -14,6 +14,7 @@ fit_cmdstanr(
   adapt_delta,
   max_treedepth,
   refresh,
+  verbose = TRUE,
   ...
 )
 }


### PR DESCRIPTION
# Summary

Three unrelated corrections, each about a claim the package made that was not
quite true.

**`prior_sensitivity()` forwarded `...` to every refit,** so a caller could
change the model there while the sweep claimed to vary only the prior scale.
Model-defining arguments are now rejected with a message naming them; sampler
and backend controls still pass through.

**`prior_normal(autoscale = TRUE)` divided only the scale by the covariate's
SD.** Autoscaling states a prior on the coefficient of a covariate measured in
SD units, so recovering it on the original scale divides the location too.
Dividing only the scale left a nonzero prior mean attached to the wrong
covariate scale. The default `mean = 0` is unaffected, since `0 / sd` is `0`, so
only priors with a deliberately nonzero location change.

**`verbose = FALSE` did not silence the sampler.** cmdstanr writes its
"Running MCMC with N chains / Chain k finished in ..." banner to stdout rather
than through the condition system, so neither `refresh = 0` nor
`suppressMessages()` stopped it: about fifteen lines per fit, which buries
anything real in a loop over many models.

## Type of Change

- [x] Bug fix

## Statistical or User-Facing Impact

`prior_normal(mean = 4, sd = 2, autoscale = TRUE)` with `sd_x = 2` now yields a
prior mean of 2 rather than 4. Priors with the default zero mean are unchanged,
which is most of them.

`prior_sensitivity(fit, model = "relaxed")` and similar now error instead of
silently sweeping a different model.

Measured: a fit with `verbose = FALSE` produces **0** stdout lines.

## Verification

```text
pure-R suite (NOT_CRAN=false)      -> pass 595  fail 0  err 0
autoscale mean 4 / sd_x 2          -> 2 (was 4)
autoscale default mean 0           -> unchanged
prior_sensitivity(model=, center=) -> both rejected
verbose = FALSE stdout lines       -> 0
lintr on changed R files           -> 0 lints
```

The backend asks `formals(mod$sample)` which of `show_messages` /
`show_exceptions` it accepts, rather than assuming a cmdstanr version, and an
explicit value in `...` still wins.

## Documentation

- [ ] README updated if needed (no change needed)
- [x] Help pages or roxygen updated if needed
- [ ] Vignettes updated if needed (documentation pull request)
- [x] NEWS.md updated for user-facing changes

## Checklist

- [x] The change is focused and reviewable
- [x] Relevant tests pass
- [x] No local build artifacts, `.Rcheck` output, tarballs, or caches are committed
- [x] The pull request follows the Code of Conduct


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `verbose` option for CmdStan sampling, allowing sampler messages and exceptions to be suppressed while respecting explicit settings.
  * Prior sensitivity analysis now permits sampler and backend controls when refitting.

* **Bug Fixes**
  * Improved validation prevents unnamed or model-defining overrides during prior sensitivity analysis.
  * Automatic prior scaling now adjusts both means and standard deviations, including safe handling of constant covariates.

* **Documentation**
  * Updated usage documentation and development notes for verbosity controls and prior scaling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->