### PR TITLE
Document the exposure and delayed-entry contracts, and the release workflow

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -8,9 +8,9 @@ on:
   # request can target: main, and the pre-release branch of an unreleased
   # version. The retired one-branch-per-release model is not among them.
   push:
-    branches: [main, master]
+    branches: [main]
   pull_request:
-    branches: [main, master, 'pre-release/**']
+    branches: [main, 'pre-release/**']
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master, 'release/**']
+    branches: [main, master, 'release/**', 'pre-release/**']
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -2,12 +2,15 @@ name: R-CMD-check
 
 on:
   # push only on the long-lived branches; pull_request covers everything else.
-  # Listing release/** in both made every push to a branch with an open PR run
-  # the whole matrix twice on the same commit.
+  # Listing a branch pattern in both made every push to a branch with an open
+  # PR run the whole matrix twice on the same commit. The pull_request filter
+  # matches the BASE branch, so it names the integration branches a pull
+  # request can target: main, and the pre-release branch of an unreleased
+  # version. The retired one-branch-per-release model is not among them.
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master, 'release/**', 'pre-release/**']
+    branches: [main, master, 'pre-release/**']
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -207,10 +207,12 @@ jobs:
 
           # The point of this job is that NOT_CRAN=true actually runs the Stan
           # tests, so a skip whose reason is CRAN means the coverage silently
-          # went away and must fail the job. skip_on_ci() is a separate,
-          # deliberate decoration for the handful of tests that really are too
-          # slow for a runner (test-survival-predict.R's far-extrapolation sweep
-          # measures ~66 minutes); list those but do not fail on them.
+          # went away and must fail the job. Every OTHER skip reason is
+          # listed rather than failed on, because a test can legitimately skip
+          # for a missing optional dependency or an absent toolchain. No test
+          # currently carries skip_on_ci(); the listing is what makes one added
+          # later visible, instead of quietly removing coverage from the only
+          # job that runs the Stan suite.
           reasons <- unlist(lapply(res, function(f) {
             vapply(f$results, function(r) {
               if (inherits(r, "expectation_skip")) conditionMessage(r) else NA_character_

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -2,7 +2,7 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: [main]
   pull_request:
   release:
     types: [published]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,9 +36,11 @@ Everything reaches an integration branch through a pull request, including work
 by the maintainer, because the pull request is what runs the checks, produces a
 reviewable diff, and records why a change was made.
 
-`main` always holds the released state. Work for a version that has not been
-released yet integrates on `pre-release/vX.Y.Z` instead, and that branch is
-merged into `main` as one reviewed step when the version is released. A single
+`main` holds the released state, with one exception: from a CRAN submission
+until a version is accepted, it holds the most recent commit submitted to CRAN,
+and nothing else merges into it. Work for a version that has not been released
+yet integrates on `pre-release/vX.Y.Z` instead, and that branch is merged into
+`main` as one reviewed step when the version is ready to submit. A single
 change therefore has one pull request, targeting whichever of the two is the
 current integration branch; it is not opened twice.
 
@@ -80,11 +82,14 @@ the changes themselves:
   precompiled vignettes, `CITATION.cff`, and `codemeta.json`.
 
 The pre-release branch is merged into `main` by pull request once the full
-check matrix is green. The version tag `vX.Y.Z` and the GitHub release are created
-from the merged commit only after CRAN accepts it; while a submission is
-pending, that commit is immutable. If CRAN asks for changes, increment to the
-next version rather than reusing the submitted one, and note the resubmission
-in `cran-comments.md`.
+check matrix is green, and the merged commit is what is submitted to CRAN. The
+version tag `vX.Y.Z` and the GitHub release are created from that commit only
+after CRAN accepts it. While a submission is pending, the submitted commit is
+immutable and nothing else is merged into `main`, so `main` is either the
+released state or the most recent commit submitted to CRAN, never a mixture of
+a submitted version and later work. If CRAN asks for changes, increment to the
+next version rather than reusing the submitted one, merge the resubmission the
+same way, and note it in `cran-comments.md`.
 
 ## Code Style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,8 +44,10 @@ yet integrates on `pre-release/vX.Y.Z` instead, and that branch is merged into
 change therefore has one pull request, targeting whichever of the two is the
 current integration branch; it is not opened twice.
 
-- **One branch per logical change, never one branch per release.** A release is
-  a milestone, a `NEWS.md` heading, and a tag; it is not a unit of review.
+- **One branch per logical change, never one change branch per release.** A
+  release is a milestone, a `NEWS.md` heading, and a tag; it is not a unit of
+  review. The pre-release integration branch is not what this rule is about: it
+  collects changes that were each reviewed on their own branch and pull request.
   Branch names should describe the change (`survival-rmst-predictions`,
   `interval-censoring-validation`). A prefix such as `feature/` or `fix/` is
   optional.
@@ -66,8 +68,10 @@ current integration branch; it is not opened twice.
 
 Between releases the integration branch carries a development version
 (`0.1.0.9000`), so add `NEWS.md` entries as the work lands rather than
-reconstructing them later. The version in `DESCRIPTION` is not bumped as work
-accumulates; it is set once, during release preparation.
+reconstructing them later. The development version is set in the first commit
+on a new pre-release branch, immediately after the release it follows, so no
+development commit carries a released version number. It is not bumped as work
+accumulates; the release version is set once, during release preparation.
 
 ## Releases
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,8 @@ current integration branch; it is not opened twice.
   resolution, and informative blame. Keep changes separable.
 - Commit as often as is useful while working. Pull requests are squash-merged,
   so each commit on the integration branch is one complete, tested, revertible
-  change.
+  change. The one exception is the pull request that merges a pre-release
+  branch into `main`; see Releases.
 - Write commit subjects in the imperative ("Add M-spline survival baselines").
   Conventional Commit prefixes are not used here.
 - `git commit --amend` and `git push --force-with-lease` are acceptable only on
@@ -82,9 +83,12 @@ the changes themselves:
   precompiled vignettes, `CITATION.cff`, and `codemeta.json`.
 
 The pre-release branch is merged into `main` by pull request once the full
-check matrix is green, and the merged commit is what is submitted to CRAN. The
-version tag `vX.Y.Z` and the GitHub release are created from that commit only
-after CRAN accepts it. While a submission is pending, the submitted commit is
+check matrix is green. That pull request is merged with a merge commit, not
+squashed: squashing would collapse every change on the pre-release branch into
+one commit on `main` and discard exactly the per-change history the branch was
+kept to preserve. The merge commit is what is submitted to CRAN. The version
+tag `vX.Y.Z` and the GitHub release are created from that commit only after
+CRAN accepts it. While a submission is pending, the submitted commit is
 immutable and nothing else is merged into `main`, so `main` is either the
 released state or the most recent commit submitted to CRAN, never a mixture of
 a submitted version and later work. If CRAN asks for changes, increment to the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,9 +32,15 @@ working C++ toolchain:
 
 ## Branches and Pull Requests
 
-`main` is the only integration branch. Everything reaches it through a pull
-request, including work by the maintainer, because the pull request is what runs
-the checks, produces a reviewable diff, and records why a change was made.
+Everything reaches an integration branch through a pull request, including work
+by the maintainer, because the pull request is what runs the checks, produces a
+reviewable diff, and records why a change was made.
+
+`main` always holds the released state. Work for a version that has not been
+released yet integrates on `pre-release/vX.Y.Z` instead, and that branch is
+merged into `main` as one reviewed step when the version is released. A single
+change therefore has one pull request, targeting whichever of the two is the
+current integration branch; it is not opened twice.
 
 - **One branch per logical change, never one branch per release.** A release is
   a milestone, a `NEWS.md` heading, and a tag; it is not a unit of review.
@@ -45,7 +51,8 @@ the checks, produces a reviewable diff, and records why a change was made.
   CI evidence, targeted reverts and cherry-picks, useful `git bisect`
   resolution, and informative blame. Keep changes separable.
 - Commit as often as is useful while working. Pull requests are squash-merged,
-  so each commit on `main` is one complete, tested, revertible change.
+  so each commit on the integration branch is one complete, tested, revertible
+  change.
 - Write commit subjects in the imperative ("Add M-spline survival baselines").
   Conventional Commit prefixes are not used here.
 - `git commit --amend` and `git push --force-with-lease` are acceptable only on
@@ -54,14 +61,17 @@ the checks, produces a reviewable diff, and records why a change was made.
 - Keep implementation, its tests, the roxygen source, the regenerated
   documentation, and the `NEWS.md` bullet together in the same pull request.
 
-Between releases `main` carries a development version (`0.1.0.9000`), so add
-`NEWS.md` entries as the work lands rather than reconstructing them later.
+Between releases the integration branch carries a development version
+(`0.1.0.9000`), so add `NEWS.md` entries as the work lands rather than
+reconstructing them later. The version in `DESCRIPTION` is not bumped as work
+accumulates; it is set once, during release preparation.
 
 ## Releases
 
-Release branches use `release/vX.Y.Z` and exist only for final preparation,
-after the changes they cover are already merged into `main`. They should live
-for hours, not weeks, and contain only:
+A version under development integrates on `pre-release/vX.Y.Z`, which collects
+the pull requests for that version while `main` continues to hold the released
+state. Final preparation happens on that same branch, and it contains, beyond
+the changes themselves:
 
 - the version bump in `DESCRIPTION`,
 - the finalized `NEWS.md` section,
@@ -69,8 +79,8 @@ for hours, not weeks, and contain only:
 - regenerated artifacts: roxygen documentation, `src/stanExports_*`, the
   precompiled vignettes, `CITATION.cff`, and `codemeta.json`.
 
-The release branch is merged into `main` by pull request once the full check
-matrix is green. The version tag `vX.Y.Z` and the GitHub release are created
+The pre-release branch is merged into `main` by pull request once the full
+check matrix is green. The version tag `vX.Y.Z` and the GitHub release are created
 from the merged commit only after CRAN accepts it; while a submission is
 pending, that commit is immutable. If CRAN asks for changes, increment to the
 next version rather than reusing the submitted one, and note the resubmission

--- a/NEWS.md
+++ b/NEWS.md
@@ -574,9 +574,13 @@
   weighted by exposure, and, with person-level moments, only when exposure
   carries no information about the covariate-specific rate within the row.
   The covariate moments therefore have to describe person-time rather than
-  people; the two coincide whenever mean exposure does not vary with the
-  covariates, and published subgroup tables usually report the person-level
-  reading without saying which one they support.
+  people, and with two or more covariates so does the correlation that
+  `add_integration()` combines them with, since its default is estimated from
+  the index sample and exposure can change how the covariates go together
+  without moving any of their moments. The two populations coincide whenever
+  mean exposure does not vary with the covariates, and published subgroup
+  tables usually report the person-level reading without saying which one
+  they support.
 * `?set_agd_surv` now states which population the covariate moments must
   describe when the comparator has delayed entry. The model conditions on
   survival to entry inside the covariate integral and averages afterwards, so

--- a/NEWS.md
+++ b/NEWS.md
@@ -584,7 +584,11 @@
   baseline, pre-selection population; surviving to entry selects on the very
   covariates being integrated out. Varying entry times need one assumption
   more, since the model carries a single covariate distribution per arm and
-  each entry time selects a different subgroup.
+  each entry time selects a different subgroup. A test now compares the
+  model's aggregate delayed-entry likelihood, draw by draw, against direct
+  integration under that definition over a two-component covariate mixture,
+  and against the other order of conditioning and averaging, which gives a
+  different number.
 
 ## Dependencies
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -567,6 +567,19 @@
   vignette additionally calls one internal diagnostic helper. The survival
   vignette leads with the M-spline baseline, matching multinma's NDMM example,
   and adds a relaxed-model effect-modification section.
+* `?set_agd` now states what an aggregate Poisson row assumes about exposure.
+  The likelihood multiplies a row's total exposure by the rate averaged over
+  the supplied covariate distribution, which reproduces the sum of each
+  person's exposure times their own rate only when exposure carries no
+  information about the covariate-specific rate within the row. The covariate
+  moments therefore have to describe person-time rather than people, and
+  published subgroup tables usually report the latter.
+* `?set_agd_surv` now states which population the covariate moments must
+  describe when the comparator has delayed entry. The model conditions on
+  survival to entry inside the covariate integral and averages afterwards, so
+  the moments must be those of the population observed at entry rather than a
+  baseline, pre-selection population; surviving to entry selects on the very
+  covariates being integrated out.
 
 ## Dependencies
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -585,7 +585,8 @@
 * `?set_agd_surv` now states which population the covariate moments must
   describe when the comparator has delayed entry. The model conditions on
   survival to entry inside the covariate integral and averages afterwards, so
-  the moments must be those of the population observed at entry rather than a
+  the distribution integrated over, its shape and dependence as well as its
+  moments, must be that of the population observed at entry rather than a
   baseline, pre-selection population; surviving to entry selects on the very
   covariates being integrated out. Varying entry times need one assumption
   more, since the model carries a single covariate distribution per arm while

--- a/NEWS.md
+++ b/NEWS.md
@@ -569,13 +569,14 @@
   and adds a relaxed-model effect-modification section.
 * `?set_agd` now states what an aggregate Poisson row assumes about exposure.
   The likelihood multiplies a row's total exposure by the rate averaged over
-  the supplied covariate distribution, which reproduces the sum of each
-  person's exposure times their own rate only when exposure carries no
-  information about the covariate-specific rate within the row. The covariate
-  moments therefore have to describe person-time rather than people, which
-  coincides with the person-level distribution whenever mean exposure does not
-  vary with the covariates; published subgroup tables usually report the
-  latter without saying which reading they support.
+  the supplied covariate distribution. That reproduces the sum of each
+  person's exposure times their own rate exactly when the distribution is
+  weighted by exposure, and, with person-level moments, only when exposure
+  carries no information about the covariate-specific rate within the row.
+  The covariate moments therefore have to describe person-time rather than
+  people; the two coincide whenever mean exposure does not vary with the
+  covariates, and published subgroup tables usually report the person-level
+  reading without saying which one they support.
 * `?set_agd_surv` now states which population the covariate moments must
   describe when the comparator has delayed entry. The model conditions on
   survival to entry inside the covariate integral and averages afterwards, so

--- a/NEWS.md
+++ b/NEWS.md
@@ -572,14 +572,18 @@
   the supplied covariate distribution, which reproduces the sum of each
   person's exposure times their own rate only when exposure carries no
   information about the covariate-specific rate within the row. The covariate
-  moments therefore have to describe person-time rather than people, and
-  published subgroup tables usually report the latter.
+  moments therefore have to describe person-time rather than people, which
+  coincides with the person-level distribution whenever mean exposure does not
+  vary with the covariates; published subgroup tables usually report the
+  latter without saying which reading they support.
 * `?set_agd_surv` now states which population the covariate moments must
   describe when the comparator has delayed entry. The model conditions on
   survival to entry inside the covariate integral and averages afterwards, so
   the moments must be those of the population observed at entry rather than a
   baseline, pre-selection population; surviving to entry selects on the very
-  covariates being integrated out.
+  covariates being integrated out. Varying entry times need one assumption
+  more, since the model carries a single covariate distribution per arm and
+  each entry time selects a different subgroup.
 
 ## Dependencies
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -573,22 +573,25 @@
   person's exposure times their own rate exactly when the distribution is
   weighted by exposure, and, with person-level moments, only when exposure
   carries no information about the covariate-specific rate within the row.
-  The covariate moments therefore have to describe person-time rather than
-  people, and with two or more covariates so does the correlation that
-  `add_integration()` combines them with, since its default is estimated from
-  the index sample and exposure can change how the covariates go together
-  without moving any of their moments. The two populations coincide whenever
-  mean exposure does not vary with the covariates, and published subgroup
-  tables usually report the person-level reading without saying which one
-  they support.
+  The whole covariate distribution the rate is averaged over therefore has
+  to describe person-time rather than people: the marginal shape each
+  `distr()` assumes around the moments, and with two or more covariates the
+  correlation `add_integration()` combines them with, whose default is
+  estimated from the index sample. Exposure can change a covariate's skewness
+  or how the covariates go together without moving any of their moments. The
+  two populations coincide whenever mean exposure does not vary with the
+  covariates, and published subgroup tables usually report the person-level
+  reading without saying which one they support.
 * `?set_agd_surv` now states which population the covariate moments must
   describe when the comparator has delayed entry. The model conditions on
   survival to entry inside the covariate integral and averages afterwards, so
   the moments must be those of the population observed at entry rather than a
   baseline, pre-selection population; surviving to entry selects on the very
   covariates being integrated out. Varying entry times need one assumption
-  more, since the model carries a single covariate distribution per arm and
-  each entry time selects a different subgroup. A test now compares the
+  more, since the model carries a single covariate distribution per arm while
+  the population observed at each entry time can differ, both because each
+  entry time selects a different subgroup and because who enters when can be
+  related to the covariates. A test now compares the
   model's aggregate delayed-entry likelihood, draw by draw, against direct
   integration under that definition over a two-component covariate mixture,
   and against the other order of conditioning and averaging, which gives a

--- a/R/data_setup.R
+++ b/R/data_setup.R
@@ -488,11 +488,21 @@ set_ipd <- function(data, treatment, outcome = NULL, covariates,
 #'
 #' The assumption is therefore about person-time, not about people:
 #' `cov_means` and `cov_sds` should describe the covariate distribution
-#' weighted by exposure. Person-level moments stand in for it when exposure
-#' carries no information about the covariate-specific rate within the row.
-#' Mean exposure that does not vary with the covariates is a sufficient
-#' condition that does not depend on the model, because it makes the two
-#' distributions coincide, and equal individual exposure is its simplest case.
+#' weighted by exposure. With one covariate its moments are the whole of that
+#' distribution, as far as the integration uses it. With two or more, the
+#' dependence between them belongs to it as well: the rate is averaged over
+#' the joint distribution that [add_integration()] builds from the moments
+#' and its `cor`, and the `cor` it uses by default is estimated from the index
+#' sample. Exposure can leave every mean and standard deviation where it was
+#' and still change how the covariates go together, when it varies with
+#' their combination rather than with each on its own, so the correlation
+#' handed to [add_integration()] has to describe the person-time population
+#' too. Person-level moments stand in for exposure-weighted ones when
+#' exposure carries no information about the covariate-specific rate within
+#' the row. Mean exposure that does not vary with the covariates is a
+#' sufficient condition that does not depend on the model, because it makes
+#' the two distributions coincide, joint distribution included, and equal
+#' individual exposure is its simplest case.
 #' Published subgroup tables almost always report person-level moments, and
 #' those do not identify the person-time distribution. Where follow-up varies
 #' with a prognostic covariate, prefer rows defined so that exposure is close

--- a/R/data_setup.R
+++ b/R/data_setup.R
@@ -486,9 +486,12 @@ set_ipd <- function(data, treatment, outcome = NULL, covariates,
 #' The assumption is therefore about person-time, not about people:
 #' `cov_means` and `cov_sds` must describe the covariate distribution
 #' **weighted by exposure**. The exposure-weighted and unweighted distributions
-#' coincide whenever mean exposure does not vary with the covariates, which is
-#' the same no-association condition stated above; equal individual exposure is
-#' the simplest way to satisfy it, not the only one. Published
+#' coincide when mean exposure does not vary with the covariates. That is
+#' sufficient for the condition above and stronger than it: the likelihood needs
+#' only that exposure carry no information about the covariate-specific rate,
+#' which constant mean exposure guarantees but which can also hold without it.
+#' Equal individual exposure is the simplest way to satisfy either, not the only
+#' one. Published
 #' subgroup tables almost always report person-level moments, and those do not
 #' identify the person-time distribution. Where follow-up varies with a
 #' prognostic covariate, prefer rows defined so that exposure is close to

--- a/R/data_setup.R
+++ b/R/data_setup.R
@@ -485,8 +485,10 @@ set_ipd <- function(data, treatment, outcome = NULL, covariates,
 #'
 #' The assumption is therefore about person-time, not about people:
 #' `cov_means` and `cov_sds` must describe the covariate distribution
-#' **weighted by exposure**, which is the same thing as the unweighted
-#' distribution exactly when exposure is constant within the row. Published
+#' **weighted by exposure**. The exposure-weighted and unweighted distributions
+#' coincide whenever mean exposure does not vary with the covariates, which is
+#' the same no-association condition stated above; equal individual exposure is
+#' the simplest way to satisfy it, not the only one. Published
 #' subgroup tables almost always report person-level moments, and those do not
 #' identify the person-time distribution. Where follow-up varies with a
 #' prognostic covariate, prefer rows defined so that exposure is close to

--- a/R/data_setup.R
+++ b/R/data_setup.R
@@ -486,22 +486,21 @@ set_ipd <- function(data, treatment, outcome = NULL, covariates,
 #' reproduce the sum only when exposure carries no information about the
 #' covariate-specific rate within the row.
 #'
-#' The assumption is therefore about person-time, not about people:
-#' `cov_means` and `cov_sds` should describe the covariate distribution
-#' weighted by exposure. With one covariate its moments are the whole of that
-#' distribution, as far as the integration uses it. With two or more, the
-#' dependence between them belongs to it as well: the rate is averaged over
-#' the joint distribution that [add_integration()] builds from the moments
-#' and its `cor`, and the `cor` it uses by default is estimated from the index
-#' sample. Exposure can leave every mean and standard deviation where it was
-#' and still change how the covariates go together, when it varies with
-#' their combination rather than with each on its own, so the correlation
-#' handed to [add_integration()] has to describe the person-time population
-#' too. Person-level moments stand in for exposure-weighted ones when
-#' exposure carries no information about the covariate-specific rate within
-#' the row. Mean exposure that does not vary with the covariates is a
-#' sufficient condition that does not depend on the model, because it makes
-#' the two distributions coincide, joint distribution included, and equal
+#' The assumption is therefore about person-time, not about people, and it
+#' is about the whole distribution the rate is averaged over, not only the
+#' moments: the marginal shape that each `distr()` in [add_integration()]
+#' assumes around `cov_means` and `cov_sds`, and with two or more covariates
+#' the correlation it combines them with, whose default is estimated from the
+#' index sample. All of it has to describe the covariates weighted by
+#' exposure. Exposure can leave every mean and standard deviation where it
+#' was and still change a covariate's skewness or tails, or how the
+#' covariates go together when it varies with their combination rather than
+#' with each on its own, and the averaged rate moves with any of these.
+#' Person-level summaries stand in for exposure-weighted ones when exposure
+#' carries no information about the covariate-specific rate within the row.
+#' Mean exposure that does not vary with the covariates is a sufficient
+#' condition that does not depend on the model, because it makes the two
+#' distributions coincide, shape and dependence included, and equal
 #' individual exposure is its simplest case.
 #' Published subgroup tables almost always report person-level moments, and
 #' those do not identify the person-time distribution. Where follow-up varies

--- a/R/data_setup.R
+++ b/R/data_setup.R
@@ -477,25 +477,26 @@ set_ipd <- function(data, treatment, outcome = NULL, covariates,
 #' for a row is the total exposure multiplied by the rate averaged over the
 #' covariate distribution you supply, while the quantity it stands in for is
 #' the sum over people of each person's own exposure times that person's rate.
-#' Those two agree when exposure carries no information about the
-#' covariate-specific rate within the row; they can differ substantially when
-#' it does. Two people with rates 1 and 3 and exposures 9 and 1 are expected to
-#' contribute `9 * 1 + 1 * 3 = 12` events, whereas a total exposure of 10 times
-#' the mean rate of 2 gives 20.
+#' The two agree exactly when the supplied distribution is the one **weighted
+#' by exposure**, whatever the dependence between exposure and the covariates:
+#' two people with rates 1 and 3 and exposures 9 and 1 contribute
+#' `9 * 1 + 1 * 3 = 12` expected events, and `10 * (0.9 * 1 + 0.1 * 3)` is 12 as
+#' well. With the person-level distribution instead, the same row gives a total
+#' exposure of 10 times the mean rate of 2, which is 20. Person-level moments
+#' reproduce the sum only when exposure carries no information about the
+#' covariate-specific rate within the row.
 #'
 #' The assumption is therefore about person-time, not about people:
-#' `cov_means` and `cov_sds` must describe the covariate distribution
-#' **weighted by exposure**. The exposure-weighted and unweighted distributions
-#' coincide when mean exposure does not vary with the covariates. That is
-#' sufficient for the condition above and stronger than it: the likelihood needs
-#' only that exposure carry no information about the covariate-specific rate,
-#' which constant mean exposure guarantees but which can also hold without it.
-#' Equal individual exposure is the simplest way to satisfy either, not the only
-#' one. Published
-#' subgroup tables almost always report person-level moments, and those do not
-#' identify the person-time distribution. Where follow-up varies with a
-#' prognostic covariate, prefer rows defined so that exposure is close to
-#' constant inside each one, and say which reading the reported moments
+#' `cov_means` and `cov_sds` should describe the covariate distribution
+#' weighted by exposure. Person-level moments stand in for it when exposure
+#' carries no information about the covariate-specific rate within the row.
+#' Mean exposure that does not vary with the covariates is a sufficient
+#' condition that does not depend on the model, because it makes the two
+#' distributions coincide, and equal individual exposure is its simplest case.
+#' Published subgroup tables almost always report person-level moments, and
+#' those do not identify the person-time distribution. Where follow-up varies
+#' with a prognostic covariate, prefer rows defined so that exposure is close
+#' to constant inside each one, and say which reading the reported moments
 #' support. Weighting across rows does not repair a dependence inside a row,
 #' and nothing in the supplied summaries reveals it, so this is not checked.
 #'

--- a/R/data_setup.R
+++ b/R/data_setup.R
@@ -473,6 +473,27 @@ set_ipd <- function(data, treatment, outcome = NULL, covariates,
 #' `log(E_agd)` as an offset, so rates are modeled on the log scale
 #' regardless of how `outcome_r` is tabulated.
 #'
+#' **What the aggregate Poisson row assumes about exposure.** The likelihood
+#' for a row is the total exposure multiplied by the rate averaged over the
+#' covariate distribution you supply, while the quantity it stands in for is
+#' the sum over people of each person's own exposure times that person's rate.
+#' Those two agree when exposure carries no information about the
+#' covariate-specific rate within the row; they can differ substantially when
+#' it does. Two people with rates 1 and 3 and exposures 9 and 1 are expected to
+#' contribute `9 * 1 + 1 * 3 = 12` events, whereas a total exposure of 10 times
+#' the mean rate of 2 gives 20.
+#'
+#' The assumption is therefore about person-time, not about people:
+#' `cov_means` and `cov_sds` must describe the covariate distribution
+#' **weighted by exposure**, which is the same thing as the unweighted
+#' distribution exactly when exposure is constant within the row. Published
+#' subgroup tables almost always report person-level moments, and those do not
+#' identify the person-time distribution. Where follow-up varies with a
+#' prognostic covariate, prefer rows defined so that exposure is close to
+#' constant inside each one, and say which reading the reported moments
+#' support. Weighting across rows does not repair a dependence inside a row,
+#' and nothing in the supplied summaries reveals it, so this is not checked.
+#'
 #' **Scale assumptions for `family = "binomial"`.** `outcome_r` /
 #' `outcome_n` are counts of events and trials. The log-odds (or
 #' probit / cloglog under alternative links) are formed from

--- a/R/survival.R
+++ b/R/survival.R
@@ -292,6 +292,33 @@
 #'   Multi-arm reconstructed survival comparators are rejected until a
 #'   weighting estimand is implemented. Defaults to a single arm.
 #'
+#' @details
+#' **Which population the covariate moments must describe under delayed
+#' entry.** For individual data the covariates are known, so dividing each
+#' person's contribution by their own survival to entry is unambiguous. Here
+#' the covariates are not observed: they are integrated out against the
+#' distribution implied by `cov_means` and `cov_sds`, and the order of the two
+#' operations matters. This model conditions first and averages second, so each
+#' integration point contributes its own delayed-entry likelihood and the row
+#' likelihood is their average. That is the right quantity when the supplied
+#' moments describe the population **as observed at entry**, meaning those who
+#' survived to their entry time and are therefore in the risk set.
+#'
+#' It is not the right quantity when the moments describe a baseline,
+#' pre-selection population, because surviving to entry is itself selective:
+#' whichever covariate values carry lower hazard are over-represented at entry
+#' relative to baseline. Averaging first and conditioning second is the form
+#' that matches baseline moments, and the two differ in general, by more when
+#' entry times are late or the covariate effects are strong. Varying entry
+#' times sharpen the distinction further, since each entry time selects a
+#' different subgroup.
+#'
+#' Published summaries are ordinarily reported for the enrolled population and
+#' are usually the right ones; state which population they came from, and treat
+#' a delayed-entry comparator whose moments are known to be pre-selection as a
+#' misspecification that no diagnostic here can detect. Delayed entry in the
+#' individual arm is unaffected by any of this.
+#'
 #' @return An object of class `mlumr_agd_surv` (also inheriting `mlumr_agd`).
 #' @seealso [set_agd()] for non-survival aggregate data.
 #'   `multinma::set_agd_surv()` is the ML-NMR equivalent; the name is given as

--- a/R/survival.R
+++ b/R/survival.R
@@ -316,11 +316,13 @@
 #' integrated against the covariate distribution among those who survived to
 #' ITS entry time, and later entrants are a more selected group than earlier
 #' ones. The model has one covariate distribution per arm and reuses it for
-#' every pseudo-individual, so pooled moments over everyone enrolled satisfy
-#' the contract above and can still give the wrong likelihood. Using them
-#' requires either a common entry time, or that the covariate distribution
-#' among survivors does not shift with entry time. Neither is checkable from
-#' the summaries supplied.
+#' every pseudo-individual. Pooled moments over everyone enrolled describe no
+#' single risk set: they mix the survivor populations of every entry time, so
+#' in general they do not meet the contract above even though everyone in them
+#' was observed at entry, and using them can give the wrong likelihood. They
+#' are right only under a common entry time, or when the covariate
+#' distribution among survivors does not shift with entry time. Neither is
+#' checkable from the summaries supplied.
 #'
 #' Published summaries are ordinarily reported for the enrolled population.
 #' Under a common entry time that is the population observed at entry, so they

--- a/R/survival.R
+++ b/R/survival.R
@@ -322,9 +322,12 @@
 #' among survivors does not shift with entry time. Neither is checkable from
 #' the summaries supplied.
 #'
-#' Published summaries are ordinarily reported for the enrolled population and
-#' are usually the right ones; state which population they came from, and treat
-#' a delayed-entry comparator whose moments are known to be pre-selection as a
+#' Published summaries are ordinarily reported for the enrolled population.
+#' Under a common entry time that is the population observed at entry, so they
+#' are the right moments; under varying entry times they are the right moments
+#' only when the covariate distribution among survivors does not shift with
+#' entry time, as above. State which population they came from, and treat a
+#' delayed-entry comparator whose moments are known to be pre-selection as a
 #' misspecification that no diagnostic here can detect. Delayed entry in the
 #' individual arm is unaffected by any of this.
 #'

--- a/R/survival.R
+++ b/R/survival.R
@@ -297,12 +297,17 @@
 #' entry.** For individual data the covariates are known, so dividing each
 #' person's contribution by their own survival to entry is unambiguous. Here
 #' the covariates are not observed: they are integrated out against the
-#' distribution implied by `cov_means` and `cov_sds`, and the order of the two
+#' distribution [add_integration()] builds, and the order of the two
 #' operations matters. This model conditions first and averages second, so each
 #' integration point contributes its own delayed-entry likelihood and the row
-#' likelihood is their average. That is the right quantity when the supplied
-#' moments describe the population **as observed at entry**, meaning those who
-#' survived to their entry time and are therefore in the risk set.
+#' likelihood is their average. That is the right quantity when the
+#' distribution integrated over describes the population **as observed at
+#' entry**, meaning those who survived to their entry time and are therefore
+#' in the risk set. The whole distribution has to, not only `cov_means` and
+#' `cov_sds`: the delayed-entry contribution is nonlinear in the covariates,
+#' so the marginal shape each `distr()` assumes and the dependence its `cor`
+#' imposes change the average as surely as the moments do, and two populations
+#' can share every moment while differing in either.
 #'
 #' It is not the right quantity when the moments describe a baseline,
 #' pre-selection population, because surviving to entry is itself selective:

--- a/R/survival.R
+++ b/R/survival.R
@@ -313,25 +313,31 @@
 #'
 #' Varying entry times need one assumption more, because then there is no
 #' single population observed at entry: each pseudo-individual should be
-#' integrated against the covariate distribution among those who survived to
-#' ITS entry time, and later entrants are a more selected group than earlier
-#' ones. The model has one covariate distribution per arm and reuses it for
-#' every pseudo-individual. Pooled moments over everyone enrolled describe no
-#' single risk set: they mix the survivor populations of every entry time, so
-#' in general they do not meet the contract above even though everyone in them
-#' was observed at entry, and using them can give the wrong likelihood. They
-#' are right only under a common entry time, or when the covariate
-#' distribution among survivors does not shift with entry time. Neither is
-#' checkable from the summaries supplied.
+#' integrated against the covariate distribution among those observed at ITS
+#' entry time, the people who entered then and had survived to it. That
+#' distribution can differ from one entry time to the next for two reasons:
+#' later entrants are a more selected group than earlier ones, and who enters
+#' when may itself be related to the covariates, since cohorts enrolled at
+#' different times can differ even when survival does not depend on the
+#' covariates at all. The model has one covariate distribution per arm and
+#' reuses it for every pseudo-individual. Pooled moments over everyone
+#' enrolled describe no single risk set: they mix the populations observed at
+#' every entry time, so in general they do not meet the contract above even
+#' though everyone in them was observed at entry, and using them can give the
+#' wrong likelihood. They are right only under a common entry time, or when
+#' the covariate distribution among those observed at entry is the same at
+#' every entry time, which needs both that survival to entry selects the same
+#' way at every entry time and that entry time is unrelated to the
+#' covariates. Neither is checkable from the summaries supplied.
 #'
 #' Published summaries are ordinarily reported for the enrolled population.
 #' Under a common entry time that is the population observed at entry, so they
 #' are the right moments; under varying entry times they are the right moments
-#' only when the covariate distribution among survivors does not shift with
-#' entry time, as above. State which population they came from, and treat a
-#' delayed-entry comparator whose moments are known to be pre-selection as a
-#' misspecification that no diagnostic here can detect. Delayed entry in the
-#' individual arm is unaffected by any of this.
+#' only when the covariate distribution among those observed at entry is the
+#' same at every entry time, as above. State which population they came from,
+#' and treat a delayed-entry comparator whose moments are known to be
+#' pre-selection as a misspecification that no diagnostic here can detect.
+#' Delayed entry in the individual arm is unaffected by any of this.
 #'
 #' @return An object of class `mlumr_agd_surv` (also inheriting `mlumr_agd`).
 #' @seealso [set_agd()] for non-survival aggregate data.

--- a/R/survival.R
+++ b/R/survival.R
@@ -309,9 +309,18 @@
 #' whichever covariate values carry lower hazard are over-represented at entry
 #' relative to baseline. Averaging first and conditioning second is the form
 #' that matches baseline moments, and the two differ in general, by more when
-#' entry times are late or the covariate effects are strong. Varying entry
-#' times sharpen the distinction further, since each entry time selects a
-#' different subgroup.
+#' entry times are late or the covariate effects are strong.
+#'
+#' Varying entry times need one assumption more, because then there is no
+#' single population observed at entry: each pseudo-individual should be
+#' integrated against the covariate distribution among those who survived to
+#' ITS entry time, and later entrants are a more selected group than earlier
+#' ones. The model has one covariate distribution per arm and reuses it for
+#' every pseudo-individual, so pooled moments over everyone enrolled satisfy
+#' the contract above and can still give the wrong likelihood. Using them
+#' requires either a common entry time, or that the covariate distribution
+#' among survivors does not shift with entry time. Neither is checkable from
+#' the summaries supplied.
 #'
 #' Published summaries are ordinarily reported for the enrolled population and
 #' are usually the right ones; state which population they came from, and treat

--- a/R/survival.R
+++ b/R/survival.R
@@ -326,9 +326,10 @@
 #' though everyone in them was observed at entry, and using them can give the
 #' wrong likelihood. They are right only under a common entry time, or when
 #' the covariate distribution among those observed at entry is the same at
-#' every entry time, which needs both that survival to entry selects the same
-#' way at every entry time and that entry time is unrelated to the
-#' covariates. Neither is checkable from the summaries supplied.
+#' every entry time. That holds, for instance, when survival to entry selects
+#' the same way at every entry time and entry time is unrelated to the
+#' covariates; it is the sameness that matters, not how it comes about.
+#' Neither condition is checkable from the summaries supplied.
 #'
 #' Published summaries are ordinarily reported for the enrolled population.
 #' Under a common entry time that is the population observed at entry, so they

--- a/man/set_agd.Rd
+++ b/man/set_agd.Rd
@@ -97,25 +97,26 @@ regardless of how \code{outcome_r} is tabulated.
 for a row is the total exposure multiplied by the rate averaged over the
 covariate distribution you supply, while the quantity it stands in for is
 the sum over people of each person's own exposure times that person's rate.
-Those two agree when exposure carries no information about the
-covariate-specific rate within the row; they can differ substantially when
-it does. Two people with rates 1 and 3 and exposures 9 and 1 are expected to
-contribute \code{9 * 1 + 1 * 3 = 12} events, whereas a total exposure of 10 times
-the mean rate of 2 gives 20.
+The two agree exactly when the supplied distribution is the one \strong{weighted
+by exposure}, whatever the dependence between exposure and the covariates:
+two people with rates 1 and 3 and exposures 9 and 1 contribute
+\code{9 * 1 + 1 * 3 = 12} expected events, and \code{10 * (0.9 * 1 + 0.1 * 3)} is 12 as
+well. With the person-level distribution instead, the same row gives a total
+exposure of 10 times the mean rate of 2, which is 20. Person-level moments
+reproduce the sum only when exposure carries no information about the
+covariate-specific rate within the row.
 
 The assumption is therefore about person-time, not about people:
-\code{cov_means} and \code{cov_sds} must describe the covariate distribution
-\strong{weighted by exposure}. The exposure-weighted and unweighted distributions
-coincide when mean exposure does not vary with the covariates. That is
-sufficient for the condition above and stronger than it: the likelihood needs
-only that exposure carry no information about the covariate-specific rate,
-which constant mean exposure guarantees but which can also hold without it.
-Equal individual exposure is the simplest way to satisfy either, not the only
-one. Published
-subgroup tables almost always report person-level moments, and those do not
-identify the person-time distribution. Where follow-up varies with a
-prognostic covariate, prefer rows defined so that exposure is close to
-constant inside each one, and say which reading the reported moments
+\code{cov_means} and \code{cov_sds} should describe the covariate distribution
+weighted by exposure. Person-level moments stand in for it when exposure
+carries no information about the covariate-specific rate within the row.
+Mean exposure that does not vary with the covariates is a sufficient
+condition that does not depend on the model, because it makes the two
+distributions coincide, and equal individual exposure is its simplest case.
+Published subgroup tables almost always report person-level moments, and
+those do not identify the person-time distribution. Where follow-up varies
+with a prognostic covariate, prefer rows defined so that exposure is close
+to constant inside each one, and say which reading the reported moments
 support. Weighting across rows does not repair a dependence inside a row,
 and nothing in the supplied summaries reveals it, so this is not checked.
 

--- a/man/set_agd.Rd
+++ b/man/set_agd.Rd
@@ -106,22 +106,21 @@ exposure of 10 times the mean rate of 2, which is 20. Person-level moments
 reproduce the sum only when exposure carries no information about the
 covariate-specific rate within the row.
 
-The assumption is therefore about person-time, not about people:
-\code{cov_means} and \code{cov_sds} should describe the covariate distribution
-weighted by exposure. With one covariate its moments are the whole of that
-distribution, as far as the integration uses it. With two or more, the
-dependence between them belongs to it as well: the rate is averaged over
-the joint distribution that \code{\link[=add_integration]{add_integration()}} builds from the moments
-and its \code{cor}, and the \code{cor} it uses by default is estimated from the index
-sample. Exposure can leave every mean and standard deviation where it was
-and still change how the covariates go together, when it varies with
-their combination rather than with each on its own, so the correlation
-handed to \code{\link[=add_integration]{add_integration()}} has to describe the person-time population
-too. Person-level moments stand in for exposure-weighted ones when
-exposure carries no information about the covariate-specific rate within
-the row. Mean exposure that does not vary with the covariates is a
-sufficient condition that does not depend on the model, because it makes
-the two distributions coincide, joint distribution included, and equal
+The assumption is therefore about person-time, not about people, and it
+is about the whole distribution the rate is averaged over, not only the
+moments: the marginal shape that each \code{distr()} in \code{\link[=add_integration]{add_integration()}}
+assumes around \code{cov_means} and \code{cov_sds}, and with two or more covariates
+the correlation it combines them with, whose default is estimated from the
+index sample. All of it has to describe the covariates weighted by
+exposure. Exposure can leave every mean and standard deviation where it
+was and still change a covariate's skewness or tails, or how the
+covariates go together when it varies with their combination rather than
+with each on its own, and the averaged rate moves with any of these.
+Person-level summaries stand in for exposure-weighted ones when exposure
+carries no information about the covariate-specific rate within the row.
+Mean exposure that does not vary with the covariates is a sufficient
+condition that does not depend on the model, because it makes the two
+distributions coincide, shape and dependence included, and equal
 individual exposure is its simplest case.
 Published subgroup tables almost always report person-level moments, and
 those do not identify the person-time distribution. Where follow-up varies

--- a/man/set_agd.Rd
+++ b/man/set_agd.Rd
@@ -106,9 +106,12 @@ the mean rate of 2 gives 20.
 The assumption is therefore about person-time, not about people:
 \code{cov_means} and \code{cov_sds} must describe the covariate distribution
 \strong{weighted by exposure}. The exposure-weighted and unweighted distributions
-coincide whenever mean exposure does not vary with the covariates, which is
-the same no-association condition stated above; equal individual exposure is
-the simplest way to satisfy it, not the only one. Published
+coincide when mean exposure does not vary with the covariates. That is
+sufficient for the condition above and stronger than it: the likelihood needs
+only that exposure carry no information about the covariate-specific rate,
+which constant mean exposure guarantees but which can also hold without it.
+Equal individual exposure is the simplest way to satisfy either, not the only
+one. Published
 subgroup tables almost always report person-level moments, and those do not
 identify the person-time distribution. Where follow-up varies with a
 prognostic covariate, prefer rows defined so that exposure is close to

--- a/man/set_agd.Rd
+++ b/man/set_agd.Rd
@@ -108,11 +108,21 @@ covariate-specific rate within the row.
 
 The assumption is therefore about person-time, not about people:
 \code{cov_means} and \code{cov_sds} should describe the covariate distribution
-weighted by exposure. Person-level moments stand in for it when exposure
-carries no information about the covariate-specific rate within the row.
-Mean exposure that does not vary with the covariates is a sufficient
-condition that does not depend on the model, because it makes the two
-distributions coincide, and equal individual exposure is its simplest case.
+weighted by exposure. With one covariate its moments are the whole of that
+distribution, as far as the integration uses it. With two or more, the
+dependence between them belongs to it as well: the rate is averaged over
+the joint distribution that \code{\link[=add_integration]{add_integration()}} builds from the moments
+and its \code{cor}, and the \code{cor} it uses by default is estimated from the index
+sample. Exposure can leave every mean and standard deviation where it was
+and still change how the covariates go together, when it varies with
+their combination rather than with each on its own, so the correlation
+handed to \code{\link[=add_integration]{add_integration()}} has to describe the person-time population
+too. Person-level moments stand in for exposure-weighted ones when
+exposure carries no information about the covariate-specific rate within
+the row. Mean exposure that does not vary with the covariates is a
+sufficient condition that does not depend on the model, because it makes
+the two distributions coincide, joint distribution included, and equal
+individual exposure is its simplest case.
 Published subgroup tables almost always report person-level moments, and
 those do not identify the person-time distribution. Where follow-up varies
 with a prognostic covariate, prefer rows defined so that exposure is close

--- a/man/set_agd.Rd
+++ b/man/set_agd.Rd
@@ -105,8 +105,11 @@ the mean rate of 2 gives 20.
 
 The assumption is therefore about person-time, not about people:
 \code{cov_means} and \code{cov_sds} must describe the covariate distribution
-\strong{weighted by exposure}, which is the same thing as the unweighted
-distribution exactly when exposure is constant within the row. Published
+\strong{weighted by exposure}. The exposure-weighted and unweighted
+distributions coincide whenever mean exposure does not vary with the
+covariates, which is the same no-association condition stated above; equal
+individual exposure is the simplest way to satisfy it, not the only one.
+Published
 subgroup tables almost always report person-level moments, and those do not
 identify the person-time distribution. Where follow-up varies with a
 prognostic covariate, prefer rows defined so that exposure is close to

--- a/man/set_agd.Rd
+++ b/man/set_agd.Rd
@@ -105,11 +105,10 @@ the mean rate of 2 gives 20.
 
 The assumption is therefore about person-time, not about people:
 \code{cov_means} and \code{cov_sds} must describe the covariate distribution
-\strong{weighted by exposure}. The exposure-weighted and unweighted
-distributions coincide whenever mean exposure does not vary with the
-covariates, which is the same no-association condition stated above; equal
-individual exposure is the simplest way to satisfy it, not the only one.
-Published
+\strong{weighted by exposure}. The exposure-weighted and unweighted distributions
+coincide whenever mean exposure does not vary with the covariates, which is
+the same no-association condition stated above; equal individual exposure is
+the simplest way to satisfy it, not the only one. Published
 subgroup tables almost always report person-level moments, and those do not
 identify the person-time distribution. Where follow-up varies with a
 prognostic covariate, prefer rows defined so that exposure is close to

--- a/man/set_agd.Rd
+++ b/man/set_agd.Rd
@@ -93,6 +93,27 @@ person-time (or other exposure). The Stan likelihood uses
 \code{log(E_agd)} as an offset, so rates are modeled on the log scale
 regardless of how \code{outcome_r} is tabulated.
 
+\strong{What the aggregate Poisson row assumes about exposure.} The likelihood
+for a row is the total exposure multiplied by the rate averaged over the
+covariate distribution you supply, while the quantity it stands in for is
+the sum over people of each person's own exposure times that person's rate.
+Those two agree when exposure carries no information about the
+covariate-specific rate within the row; they can differ substantially when
+it does. Two people with rates 1 and 3 and exposures 9 and 1 are expected to
+contribute \code{9 * 1 + 1 * 3 = 12} events, whereas a total exposure of 10 times
+the mean rate of 2 gives 20.
+
+The assumption is therefore about person-time, not about people:
+\code{cov_means} and \code{cov_sds} must describe the covariate distribution
+\strong{weighted by exposure}, which is the same thing as the unweighted
+distribution exactly when exposure is constant within the row. Published
+subgroup tables almost always report person-level moments, and those do not
+identify the person-time distribution. Where follow-up varies with a
+prognostic covariate, prefer rows defined so that exposure is close to
+constant inside each one, and say which reading the reported moments
+support. Weighting across rows does not repair a dependence inside a row,
+and nothing in the supplied summaries reveals it, so this is not checked.
+
 \strong{Scale assumptions for \code{family = "binomial"}.} \code{outcome_r} /
 \code{outcome_n} are counts of events and trials. The log-odds (or
 probit / cloglog under alternative links) are formed from

--- a/man/set_agd_surv.Rd
+++ b/man/set_agd_surv.Rd
@@ -75,9 +75,17 @@ pre-selection population, because surviving to entry is itself selective:
 whichever covariate values carry lower hazard are over-represented at entry
 relative to baseline. Averaging first and conditioning second is the form
 that matches baseline moments, and the two differ in general, by more when
-entry times are late or the covariate effects are strong. Varying entry
-times sharpen the distinction further, since each entry time selects a
-different subgroup.
+entry times are late or the covariate effects are strong.
+
+Varying entry times need one assumption more, because then there is no single
+population observed at entry: each pseudo-individual should be integrated
+against the covariate distribution among those who survived to ITS entry time,
+and later entrants are a more selected group than earlier ones. The model has
+one covariate distribution per arm and reuses it for every pseudo-individual,
+so pooled moments over everyone enrolled satisfy the contract above and can
+still give the wrong likelihood. Using them requires either a common entry
+time, or that the covariate distribution among survivors does not shift with
+entry time. Neither is checkable from the summaries supplied.
 
 Published summaries are ordinarily reported for the enrolled population and
 are usually the right ones; state which population they came from, and treat

--- a/man/set_agd_surv.Rd
+++ b/man/set_agd_surv.Rd
@@ -79,25 +79,31 @@ entry times are late or the covariate effects are strong.
 
 Varying entry times need one assumption more, because then there is no
 single population observed at entry: each pseudo-individual should be
-integrated against the covariate distribution among those who survived to
-ITS entry time, and later entrants are a more selected group than earlier
-ones. The model has one covariate distribution per arm and reuses it for
-every pseudo-individual. Pooled moments over everyone enrolled describe no
-single risk set: they mix the survivor populations of every entry time, so
-in general they do not meet the contract above even though everyone in them
-was observed at entry, and using them can give the wrong likelihood. They
-are right only under a common entry time, or when the covariate
-distribution among survivors does not shift with entry time. Neither is
-checkable from the summaries supplied.
+integrated against the covariate distribution among those observed at ITS
+entry time, the people who entered then and had survived to it. That
+distribution can differ from one entry time to the next for two reasons:
+later entrants are a more selected group than earlier ones, and who enters
+when may itself be related to the covariates, since cohorts enrolled at
+different times can differ even when survival does not depend on the
+covariates at all. The model has one covariate distribution per arm and
+reuses it for every pseudo-individual. Pooled moments over everyone
+enrolled describe no single risk set: they mix the populations observed at
+every entry time, so in general they do not meet the contract above even
+though everyone in them was observed at entry, and using them can give the
+wrong likelihood. They are right only under a common entry time, or when
+the covariate distribution among those observed at entry is the same at
+every entry time, which needs both that survival to entry selects the same
+way at every entry time and that entry time is unrelated to the
+covariates. Neither is checkable from the summaries supplied.
 
 Published summaries are ordinarily reported for the enrolled population.
 Under a common entry time that is the population observed at entry, so they
 are the right moments; under varying entry times they are the right moments
-only when the covariate distribution among survivors does not shift with
-entry time, as above. State which population they came from, and treat a
-delayed-entry comparator whose moments are known to be pre-selection as a
-misspecification that no diagnostic here can detect. Delayed entry in the
-individual arm is unaffected by any of this.
+only when the covariate distribution among those observed at entry is the
+same at every entry time, as above. State which population they came from,
+and treat a delayed-entry comparator whose moments are known to be
+pre-selection as a misspecification that no diagnostic here can detect.
+Delayed entry in the individual arm is unaffected by any of this.
 }
 \examples{
 \dontrun{

--- a/man/set_agd_surv.Rd
+++ b/man/set_agd_surv.Rd
@@ -77,19 +77,23 @@ relative to baseline. Averaging first and conditioning second is the form
 that matches baseline moments, and the two differ in general, by more when
 entry times are late or the covariate effects are strong.
 
-Varying entry times need one assumption more, because then there is no single
-population observed at entry: each pseudo-individual should be integrated
-against the covariate distribution among those who survived to ITS entry time,
-and later entrants are a more selected group than earlier ones. The model has
-one covariate distribution per arm and reuses it for every pseudo-individual,
-so pooled moments over everyone enrolled satisfy the contract above and can
-still give the wrong likelihood. Using them requires either a common entry
-time, or that the covariate distribution among survivors does not shift with
-entry time. Neither is checkable from the summaries supplied.
+Varying entry times need one assumption more, because then there is no
+single population observed at entry: each pseudo-individual should be
+integrated against the covariate distribution among those who survived to
+ITS entry time, and later entrants are a more selected group than earlier
+ones. The model has one covariate distribution per arm and reuses it for
+every pseudo-individual, so pooled moments over everyone enrolled satisfy
+the contract above and can still give the wrong likelihood. Using them
+requires either a common entry time, or that the covariate distribution
+among survivors does not shift with entry time. Neither is checkable from
+the summaries supplied.
 
-Published summaries are ordinarily reported for the enrolled population and
-are usually the right ones; state which population they came from, and treat
-a delayed-entry comparator whose moments are known to be pre-selection as a
+Published summaries are ordinarily reported for the enrolled population.
+Under a common entry time that is the population observed at entry, so they
+are the right moments; under varying entry times they are the right moments
+only when the covariate distribution among survivors does not shift with
+entry time, as above. State which population they came from, and treat a
+delayed-entry comparator whose moments are known to be pre-selection as a
 misspecification that no diagnostic here can detect. Delayed entry in the
 individual arm is unaffected by any of this.
 }

--- a/man/set_agd_surv.Rd
+++ b/man/set_agd_surv.Rd
@@ -92,9 +92,10 @@ every entry time, so in general they do not meet the contract above even
 though everyone in them was observed at entry, and using them can give the
 wrong likelihood. They are right only under a common entry time, or when
 the covariate distribution among those observed at entry is the same at
-every entry time, which needs both that survival to entry selects the same
-way at every entry time and that entry time is unrelated to the
-covariates. Neither is checkable from the summaries supplied.
+every entry time. That holds, for instance, when survival to entry selects
+the same way at every entry time and entry time is unrelated to the
+covariates; it is the sameness that matters, not how it comes about.
+Neither condition is checkable from the summaries supplied.
 
 Published summaries are ordinarily reported for the enrolled population.
 Under a common entry time that is the population observed at entry, so they

--- a/man/set_agd_surv.Rd
+++ b/man/set_agd_surv.Rd
@@ -63,12 +63,17 @@ covariate distribution implied by those moments.
 entry.} For individual data the covariates are known, so dividing each
 person's contribution by their own survival to entry is unambiguous. Here
 the covariates are not observed: they are integrated out against the
-distribution implied by \code{cov_means} and \code{cov_sds}, and the order of the two
+distribution \code{\link[=add_integration]{add_integration()}} builds, and the order of the two
 operations matters. This model conditions first and averages second, so each
 integration point contributes its own delayed-entry likelihood and the row
-likelihood is their average. That is the right quantity when the supplied
-moments describe the population \strong{as observed at entry}, meaning those who
-survived to their entry time and are therefore in the risk set.
+likelihood is their average. That is the right quantity when the
+distribution integrated over describes the population \strong{as observed at
+entry}, meaning those who survived to their entry time and are therefore
+in the risk set. The whole distribution has to, not only \code{cov_means} and
+\code{cov_sds}: the delayed-entry contribution is nonlinear in the covariates,
+so the marginal shape each \code{distr()} assumes and the dependence its \code{cor}
+imposes change the average as surely as the moments do, and two populations
+can share every moment while differing in either.
 
 It is not the right quantity when the moments describe a baseline,
 pre-selection population, because surviving to entry is itself selective:

--- a/man/set_agd_surv.Rd
+++ b/man/set_agd_surv.Rd
@@ -82,11 +82,13 @@ single population observed at entry: each pseudo-individual should be
 integrated against the covariate distribution among those who survived to
 ITS entry time, and later entrants are a more selected group than earlier
 ones. The model has one covariate distribution per arm and reuses it for
-every pseudo-individual, so pooled moments over everyone enrolled satisfy
-the contract above and can still give the wrong likelihood. Using them
-requires either a common entry time, or that the covariate distribution
-among survivors does not shift with entry time. Neither is checkable from
-the summaries supplied.
+every pseudo-individual. Pooled moments over everyone enrolled describe no
+single risk set: they mix the survivor populations of every entry time, so
+in general they do not meet the contract above even though everyone in them
+was observed at entry, and using them can give the wrong likelihood. They
+are right only under a common entry time, or when the covariate
+distribution among survivors does not shift with entry time. Neither is
+checkable from the summaries supplied.
 
 Published summaries are ordinarily reported for the enrolled population.
 Under a common entry time that is the population observed at entry, so they

--- a/man/set_agd_surv.Rd
+++ b/man/set_agd_surv.Rd
@@ -58,6 +58,33 @@ via the Guyot algorithm) together with summary covariate moments
 (means/SDs). The Stan model integrates the comparator likelihood over the
 covariate distribution implied by those moments.
 }
+\details{
+\strong{Which population the covariate moments must describe under delayed
+entry.} For individual data the covariates are known, so dividing each
+person's contribution by their own survival to entry is unambiguous. Here
+the covariates are not observed: they are integrated out against the
+distribution implied by \code{cov_means} and \code{cov_sds}, and the order of the two
+operations matters. This model conditions first and averages second, so each
+integration point contributes its own delayed-entry likelihood and the row
+likelihood is their average. That is the right quantity when the supplied
+moments describe the population \strong{as observed at entry}, meaning those who
+survived to their entry time and are therefore in the risk set.
+
+It is not the right quantity when the moments describe a baseline,
+pre-selection population, because surviving to entry is itself selective:
+whichever covariate values carry lower hazard are over-represented at entry
+relative to baseline. Averaging first and conditioning second is the form
+that matches baseline moments, and the two differ in general, by more when
+entry times are late or the covariate effects are strong. Varying entry
+times sharpen the distinction further, since each entry time selects a
+different subgroup.
+
+Published summaries are ordinarily reported for the enrolled population and
+are usually the right ones; state which population they came from, and treat
+a delayed-entry comparator whose moments are known to be pre-selection as a
+misspecification that no diagnostic here can detect. Delayed entry in the
+individual arm is unaffected by any of this.
+}
 \examples{
 \dontrun{
 agd <- set_agd_surv(

--- a/tests/testthat/test-survival-delayed-entry-aggregate.R
+++ b/tests/testthat/test-survival-delayed-entry-aggregate.R
@@ -96,9 +96,13 @@ test_that("the aggregate delayed-entry likelihood conditions on entry before ave
       ll_other[s, j] <- log(sum(w * num)) - log(sum(w * exp(-h * d_j[j])))
     }
   }
-  expect_equal(ll_stan, ll_grid, tolerance = 1e-8, ignore_attr = TRUE)
-  expect_equal(ll_stan, ll_exact, tolerance = 1e-8, ignore_attr = TRUE)
-  # The two orders differ by more than the tolerance above, so the agreement
-  # is with the documented order and not with both.
-  expect_gt(max(abs(ll_stan - ll_other)), 1e-3)
+  # Absolute, not relative: the draws come back through the backend's output
+  # files, and CmdStan writes them with six significant figures, so a value
+  # recomputed from the rounded parameters differs at that level. The other
+  # order differs by orders of magnitude more, so the agreement is with the
+  # documented order and not with both.
+  expect_lt(max(abs(ll_stan - ll_grid)), 1e-4)
+  expect_lt(max(abs(ll_stan - ll_exact)), 1e-4)
+  expect_gt(max(abs(ll_stan - ll_other)), 1e-2)
+  expect_gt(stats::median(abs(ll_stan - ll_other)), 1e-2)
 })

--- a/tests/testthat/test-survival-delayed-entry-aggregate.R
+++ b/tests/testthat/test-survival-delayed-entry-aggregate.R
@@ -1,0 +1,104 @@
+# A comparator pseudo-individual under delayed entry contributes a likelihood
+# conditional on having survived to entry. With individual data the covariates
+# are known and the conditioning is unambiguous. With aggregate data they are
+# integrated out, and the order matters:
+#
+#   E_X[ f(t | X) / S(entry | X) ]        conditions first, averages second;
+#   E_X[ f(t | X) ] / E_X[ S(entry | X) ] averages first, conditions second.
+#
+# The model does the first, which is the right form when the supplied covariate
+# moments describe the population observed at entry; `?set_agd_surv` says so.
+# The IPD delayed-entry tests cannot establish that the aggregate path does
+# this, because there the covariates are known and the two orders coincide.
+# This compares the Stan likelihood, draw by draw, against R's own integration
+# under a two-component covariate mixture where the exact expectation is a
+# two-term sum, and checks that the other order would have given a different
+# number, so the comparison can tell them apart.
+
+test_that("the aggregate delayed-entry likelihood conditions on entry before averaging", {
+  skip_on_cran()
+  set.seed(2026)
+  beta <- 0.7
+
+  # Index IPD: exponential hazards, one binary covariate.
+  n_ipd <- 60L
+  x <- stats::rbinom(n_ipd, 1, 0.5)
+  t_ev <- stats::rexp(n_ipd, exp(-1 + beta * x))
+  t_c <- stats::rexp(n_ipd, 0.3)
+  ipd <- data.frame(trt = "A", time = pmin(t_ev, t_c),
+                    status = as.integer(t_ev <= t_c), x = x)
+  ipd_obj <- set_ipd(ipd, "trt", covariates = "x", family = "survival",
+                     time = "time", status = "status")
+
+  # Comparator pseudo-individuals, every one entering late.
+  n_agd <- 40L
+  xc <- stats::rbinom(n_agd, 1, 0.5)
+  entry <- stats::runif(n_agd, 0.1, 1.5)
+  t_ev <- entry + stats::rexp(n_agd, exp(-0.6 + beta * xc))
+  t_c <- entry + stats::rexp(n_agd, 0.3)
+  agd <- data.frame(trt = "B", time = pmin(t_ev, t_c),
+                    status = as.integer(t_ev <= t_c), entry = entry,
+                    x_mean = 0.5)
+  agd_obj <- set_agd_surv(agd, "trt", time = "time", status = "status",
+                          entry_time = "entry", cov_means = "x_mean",
+                          cov_sds = NA, cov_types = "binary")
+
+  # With a binary covariate the integration grid takes two values, so the
+  # grid average IS a two-component mixture expectation with the realized
+  # proportion as its weight. That proportion is the quasi-random grid's
+  # rendering of the declared one half (64 points put 31 at one value here),
+  # and integration fidelity is a separate question covered elsewhere; this
+  # test is about the order of conditioning and averaging, so the exact
+  # expectation below uses the realized weight.
+  dat <- combine_data(ipd_obj, agd_obj)
+  dat <- add_integration(dat, n_int = 64, x = distr(qbern, prob = x_mean),
+                         verbose = FALSE)
+  fit <- mlumr(dat, model = "spfa", distribution = "exponential",
+               chains = 1, iter = 200, warmup = 100, refresh = 0, seed = 2026)
+
+  sd <- fit$stan_data
+  expect_identical(sd$dist, 1L)
+  expect_true(all(sd$agd_delay_time > 0))
+  grid <- as.numeric(sd$X_int[1, , 1])           # centered covariate values
+  center <- as.numeric(sd$cov_center)
+  expect_setequal(round(grid + center, 10), c(0, 1))
+  p1 <- mean(grid + center)
+  expect_lt(abs(p1 - 0.5), 0.05)
+  w <- c(1 - p1, p1)
+
+  t_j <- sd$agd_time
+  d_j <- sd$agd_delay_time
+  s_j <- sd$agd_status
+  # Exponential hazards: h = exp(eta), S(t) = exp(-t h), f(t) = h S(t).
+  # Conditional on survival to entry: f(t)/S(d) for an event, S(t)/S(d) for a
+  # right-censored time.
+  cond_ll <- function(eta, t, d, status) {
+    h <- exp(eta)
+    if (status == 1L) log(h) - h * (t - d) else -h * (t - d)
+  }
+  draws <- fit$draws
+  ll_stan <- as.matrix(draws[, sprintf("log_lik_agd[%d]", seq_len(n_agd))])
+  ll_grid <- ll_exact <- ll_other <- matrix(NA_real_, nrow(draws), n_agd)
+  xs <- c(0, 1) - center
+  for (s in seq_len(nrow(draws))) {
+    mu <- draws$mu_comparator[s]
+    b <- draws[["beta[1]"]][s]
+    for (j in seq_len(n_agd)) {
+      # What the model computes: average over the grid of the conditional
+      # likelihood.
+      ll_grid[s, j] <- log(mean(exp(cond_ll(mu + b * grid, t_j[j], d_j[j], s_j[j]))))
+      # The two-component expectation under the same definition.
+      ll_exact[s, j] <- log(sum(w * exp(cond_ll(mu + b * xs, t_j[j], d_j[j], s_j[j]))))
+      # The other order: average the unconditional likelihood and the
+      # survival to entry separately, then take their ratio.
+      h <- exp(mu + b * xs)
+      num <- if (s_j[j] == 1L) h * exp(-h * t_j[j]) else exp(-h * t_j[j])
+      ll_other[s, j] <- log(sum(w * num)) - log(sum(w * exp(-h * d_j[j])))
+    }
+  }
+  expect_equal(ll_stan, ll_grid, tolerance = 1e-8, ignore_attr = TRUE)
+  expect_equal(ll_stan, ll_exact, tolerance = 1e-8, ignore_attr = TRUE)
+  # The two orders differ by more than the tolerance above, so the agreement
+  # is with the documented order and not with both.
+  expect_gt(max(abs(ll_stan - ll_other)), 1e-3)
+})


### PR DESCRIPTION
Four documentation corrections and one new test. No behavior changes.

**The aggregate Poisson exposure contract.** The likelihood for an aggregate
row multiplies the row's total exposure by the rate averaged over the supplied
covariate distribution, and the quantity it stands in for is the sum over
people of each person's own exposure times that person's rate. Those agree
only when exposure carries no information about the covariate-specific rate
inside the row: two people with rates 1 and 3 and exposures 9 and 1 contribute
12 expected events, while a total exposure of 10 times the mean rate of 2 gives
20. So the assumption is about person-time rather than people, and it falls on
the whole distribution the rate is averaged over: the marginal shape each
`distr()` assumes around the moments, and with two or more covariates the
correlation `add_integration()` combines them with, whose default is estimated
from the index sample. Exposure can change a covariate's skewness, its tails,
or how the covariates go together while leaving every moment in place.
Published subgroup tables almost always report person-level summaries, and
nothing in them reveals the dependence, so `?set_agd` states the assumption
rather than pretending to check it, and points at row definitions that keep
exposure close to constant.

**Which population delayed-entry comparator moments describe.** With
individual data the covariates are known, so dividing by survival to entry is
unambiguous. With aggregate data they are integrated out and the order matters:
the model conditions inside the covariate integral and averages afterwards,
which is right when the distribution integrated over describes the population
observed at entry, and wrong for baseline, pre-selection summaries, because
surviving to entry selects on the very covariates being integrated over. Here
too it is the whole distribution and not only the moments, since the
delayed-entry contribution is nonlinear in the covariates. Varying entry times
need one assumption more, because each entry time has its own observed
population; pooled enrolled moments describe none of them unless that
population is the same at every entry time, which holds for instance when
survival selects the same way at every entry time and entry time is unrelated
to the covariates. `?set_agd_surv` says so, and says the misspecification is
undetectable from the data supplied.

A new test compares the model's aggregate delayed-entry likelihood, draw by
draw, against direct integration under that definition over a two-component
covariate mixture, and against the other order of conditioning and averaging,
which gives a different number. It is compared at the precision the backend
returns rather than at machine precision, since draws read back from CmdStan
CSV carry six significant figures.

**The skip listing in the full test suite job.** Its comment justified listing
skips by naming a call site that does not exist. The comment now says what the
listing is for, which is making a skip added later visible instead of quietly
removing coverage from the only job that runs the Stan suite.

**CONTRIBUTING versus the process in use.** The document described `main` as
the only integration branch and release branches as short-lived things cut
after their changes had already merged there. The process is the opposite: a
version under development integrates on `pre-release/vX.Y.Z`, which merges into
`main` at release. It now describes that, including which branch a single pull
request targets, and the check matrix runs on pull requests into a pre-release
branch so those changes are actually checked.
