### PR TITLE
Raise the testthat floor to the version the tests need, and sharpen four claims

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,7 +50,7 @@ LinkingTo:
     rstan (>= 2.26.0),
     StanHeaders (>= 2.26.0)
 Suggests:
-    testthat (>= 3.1.5),
+    testthat (>= 3.2.0),
     ggsurvfit,
     knitr,
     rmarkdown,

--- a/R/predict.R
+++ b/R/predict.R
@@ -1788,6 +1788,11 @@ marginal_effects <- function(object,
 #'   while the index population, the one asked for, is resolved fine, and a
 #'   warning about curves that contribute nothing to the result would tell the
 #'   user to refit for no reason.
+#' The fraction is measured on a deterministic, evenly spaced subset of at most
+#' 200 draws and 60 rows per population, not on every draw and every row, so it
+#' is an estimate of the share rather than a census of it. The subset is taken
+#' by position rather than at random, so the same fit reports the same number
+#' every time.
 #' @return `NULL`, invisibly; called for the warning.
 #' @keywords internal
 .warn_coarse_rmst_grid_builtin <- function(object,

--- a/man/dot-warn_coarse_rmst_grid_builtin.Rd
+++ b/man/dot-warn_coarse_rmst_grid_builtin.Rd
@@ -14,7 +14,12 @@
 population under a strong covariate effect can decay ahead of the grid
 while the index population, the one asked for, is resolved fine, and a
 warning about curves that contribute nothing to the result would tell the
-user to refit for no reason.}
+user to refit for no reason.
+The fraction is measured on a deterministic, evenly spaced subset of at most
+200 draws and 60 rows per population, not on every draw and every row, so it
+is an estimate of the share rather than a census of it. The subset is taken
+by position rather than at random, so the same fit reports the same number
+every time.}
 }
 \value{
 \code{NULL}, invisibly; called for the warning.

--- a/tests/testthat/helper-cmdstan.R
+++ b/tests/testthat/helper-cmdstan.R
@@ -1,0 +1,13 @@
+# Is CmdStan actually usable, not merely pointed at?
+#
+# `set_cmdstan_path()` accepts any existing directory, so `cmdstan_path()` can
+# return a path with no CmdStan in it and no error, and a guard built on it
+# lets the test through to a compile that then fails. `cmdstan_version()` reads
+# the installation and gives NA when there is nothing to read.
+cmdstan_is_usable <- function() {
+  if (!requireNamespace("cmdstanr", quietly = TRUE)) return(FALSE)
+  tryCatch(
+    !is.na(cmdstanr::cmdstan_version(error_on_NA = FALSE)),
+    error = function(e) FALSE
+  )
+}

--- a/tests/testthat/test-engine.R
+++ b/tests/testthat/test-engine.R
@@ -42,13 +42,7 @@ test_that("get_engine defaults to rstan when option is NULL", {
 test_that("cmdstanr backend fits a model end-to-end", {
   skip_on_cran()
   skip_if_not_installed("cmdstanr")
-  skip_if_not(
-    tryCatch({
-      cmdstanr::cmdstan_path()
-      TRUE
-    }, error = function(e) FALSE),
-    "CmdStan not available"
-  )
+  skip_if_not(cmdstan_is_usable(), "CmdStan not available")
 
   set.seed(2026)
   n <- 50

--- a/tests/testthat/test-survival-delayed-entry-aggregate.R
+++ b/tests/testthat/test-survival-delayed-entry-aggregate.R
@@ -17,6 +17,21 @@
 
 test_that("the aggregate delayed-entry likelihood conditions on entry before averaging", {
   skip_on_cran()
+  # This fits, so it needs whichever backend is configured to be usable.
+  # `mlumr()` resolves `engine = NULL` through `mlumr.stan_engine`, so a runner
+  # set to cmdstanr without CmdStan reaches compilation and errors here instead
+  # of skipping.
+  engine <- mlumr:::get_engine()
+  skip_if_not_installed(engine)
+  if (identical(engine, "cmdstanr")) {
+    skip_if_not(
+      tryCatch({
+        cmdstanr::cmdstan_path()
+        TRUE
+      }, error = function(e) FALSE),
+      "CmdStan is not installed"
+    )
+  }
   set.seed(2026)
   beta <- 0.7
 

--- a/tests/testthat/test-survival-delayed-entry-aggregate.R
+++ b/tests/testthat/test-survival-delayed-entry-aggregate.R
@@ -24,13 +24,7 @@ test_that("the aggregate delayed-entry likelihood conditions on entry before ave
   engine <- mlumr:::get_engine()
   skip_if_not_installed(engine)
   if (identical(engine, "cmdstanr")) {
-    skip_if_not(
-      tryCatch({
-        cmdstanr::cmdstan_path()
-        TRUE
-      }, error = function(e) FALSE),
-      "CmdStan is not installed"
-    )
+    skip_if_not(cmdstan_is_usable(), "CmdStan is not usable")
   }
   set.seed(2026)
   beta <- 0.7

--- a/vignettes/choosing-a-method.Rmd
+++ b/vignettes/choosing-a-method.Rmd
@@ -192,8 +192,10 @@ decision covers, and that population has to be stated. It is often close to the
 index trial's [@ChandlerIshakTransport], which is why the index row usually
 carries the decision, but it is not automatically either trial's. When the
 decision population is a third one, standardize to it directly by passing its
-covariate distribution as `newdata` rather than adopting whichever trial is
-nearer. The comparator rows are the like-for-like comparison against STC, which
+covariate distribution as `newdata` to `predict()` or `marginal_effects()`,
+which average over those rows, rather than adopting whichever trial is nearer.
+`conditional_effects()` takes the same data frame and returns one effect per
+profile instead, which is not a transported marginal effect. The comparator rows are the like-for-like comparison against STC, which
 standardizes to that population; naive standardizes to neither and is the
 unadjusted benchmark both rows are measured against.
 

--- a/vignettes/choosing-a-method.Rmd
+++ b/vignettes/choosing-a-method.Rmd
@@ -194,8 +194,9 @@ carries the decision, but it is not automatically either trial's. When the
 decision population is a third one, standardize to it directly by passing its
 covariate distribution as `newdata` to `predict()` or `marginal_effects()`,
 which average over those rows, rather than adopting whichever trial is nearer.
-`conditional_effects()` takes the same data frame and returns one effect per
-profile instead, which is not a transported marginal effect. The comparator rows are the like-for-like comparison against STC, which
+`conditional_effects()` takes the same data frame and evaluates at each profile
+separately rather than averaging over them, so what it returns is a set of
+conditional effects and not a transported marginal one. The comparator rows are the like-for-like comparison against STC, which
 standardizes to that population; naive standardizes to neither and is the
 unadjusted benchmark both rows are measured against.
 

--- a/vignettes/choosing-a-method.Rmd.orig
+++ b/vignettes/choosing-a-method.Rmd.orig
@@ -149,8 +149,10 @@ decision covers, and that population has to be stated. It is often close to the
 index trial's [@ChandlerIshakTransport], which is why the index row usually
 carries the decision, but it is not automatically either trial's. When the
 decision population is a third one, standardize to it directly by passing its
-covariate distribution as `newdata` rather than adopting whichever trial is
-nearer. The comparator rows are the like-for-like comparison against STC, which
+covariate distribution as `newdata` to `predict()` or `marginal_effects()`,
+which average over those rows, rather than adopting whichever trial is nearer.
+`conditional_effects()` takes the same data frame and returns one effect per
+profile instead, which is not a transported marginal effect. The comparator rows are the like-for-like comparison against STC, which
 standardizes to that population; naive standardizes to neither and is the
 unadjusted benchmark both rows are measured against.
 

--- a/vignettes/choosing-a-method.Rmd.orig
+++ b/vignettes/choosing-a-method.Rmd.orig
@@ -151,8 +151,9 @@ carries the decision, but it is not automatically either trial's. When the
 decision population is a third one, standardize to it directly by passing its
 covariate distribution as `newdata` to `predict()` or `marginal_effects()`,
 which average over those rows, rather than adopting whichever trial is nearer.
-`conditional_effects()` takes the same data frame and returns one effect per
-profile instead, which is not a transported marginal effect. The comparator rows are the like-for-like comparison against STC, which
+`conditional_effects()` takes the same data frame and evaluates at each profile
+separately rather than averaging over them, so what it returns is a set of
+conditional effects and not a transported marginal one. The comparator rows are the like-for-like comparison against STC, which
 standardizes to that population; naive standardizes to neither and is the
 unadjusted benchmark both rows are measured against.
 

--- a/vignettes/choosing-a-method.html
+++ b/vignettes/choosing-a-method.html
@@ -581,8 +581,9 @@ one, standardize to it directly by passing its covariate distribution as
 <code>newdata</code> to <code>predict()</code> or
 <code>marginal_effects()</code>, which average over those rows, rather than
 adopting whichever trial is nearer. <code>conditional_effects()</code> takes
-the same data frame and returns one effect per profile instead, which is not a
-transported marginal effect. The
+the same data frame and evaluates at each profile separately rather than
+averaging over them, so what it returns is a set of conditional effects and not
+a transported marginal one. The
 comparator rows are the like-for-like comparison against STC, which
 standardizes to that population; naive standardizes to neither and is
 the unadjusted benchmark both rows are measured against.</p>

--- a/vignettes/choosing-a-method.html
+++ b/vignettes/choosing-a-method.html
@@ -578,7 +578,11 @@ to the index trial’s <span class="citation">(<a href="#ref-ChandlerIshakTransp
 which is why the index row usually carries the decision, but it is not
 automatically either trial’s. When the decision population is a third
 one, standardize to it directly by passing its covariate distribution as
-<code>newdata</code> rather than adopting whichever trial is nearer. The
+<code>newdata</code> to <code>predict()</code> or
+<code>marginal_effects()</code>, which average over those rows, rather than
+adopting whichever trial is nearer. <code>conditional_effects()</code> takes
+the same data frame and returns one effect per profile instead, which is not a
+transported marginal effect. The
 comparator rows are the like-for-like comparison against STC, which
 standardizes to that population; naive standardizes to neither and is
 the unadjusted benchmark both rows are measured against.</p>

--- a/vignettes/data-preparation.Rmd
+++ b/vignettes/data-preparation.Rmd
@@ -94,8 +94,9 @@ For the **normal** family, `outcome_mean` and `outcome_se` must be on the
 fitting with `link = "log"`. A geometric mean will not do, and its units are
 what makes that easy to miss: it is in the original units and is still a
 different quantity. Exponentiating a log-scale mean gives the geometric mean,
-not the arithmetic one, and for a lognormal outcome with log-scale SD 1 the two
-differ by 39%. Propagating the standard error does not repair that, because the
+not the arithmetic one, and for a lognormal outcome with log-scale SD 1 the
+geometric mean is 39% below the arithmetic one, which is the same gap seen from
+the other side as the arithmetic mean being 65% above it. Propagating the standard error does not repair that, because the
 mismatch is in the estimand rather than in its uncertainty. Ask for the
 arithmetic mean and its SE. See `vignette("continuous-outcomes")`.
 

--- a/vignettes/data-preparation.Rmd
+++ b/vignettes/data-preparation.Rmd
@@ -91,8 +91,9 @@ a standard-deviation column in `cov_sds`.
 
 For the **normal** family, `outcome_mean` and `outcome_se` must be on the
 **original (arithmetic) scale**, the same scale as the IPD outcome, even when
-fitting with `link = "log"`. A geometric mean is already on that scale and is a
-different quantity: exponentiating a log-scale mean gives the geometric mean,
+fitting with `link = "log"`. A geometric mean will not do, and its units are
+what makes that easy to miss: it is in the original units and is still a
+different quantity. Exponentiating a log-scale mean gives the geometric mean,
 not the arithmetic one, and for a lognormal outcome with log-scale SD 1 the two
 differ by 39%. Propagating the standard error does not repair that, because the
 mismatch is in the estimand rather than in its uncertainty. Ask for the


### PR DESCRIPTION
Five items from the review of the branch as a whole. Three others in the same
pass are answered on their threads rather than changed, with the measurements:
two undocumented-argument warnings that `tools::checkDocFiles()` does not
report, and a Windows CI leg whose unconditional steps already cover what the
job is named for.

## The declared testthat floor predates the helper the tests use

`DESCRIPTION` allowed `testthat (>= 3.1.5)` while two test files call
`local_mocked_bindings()`. testthat's own NEWS puts it across four releases:

| release | entry |
|---|---|
| 3.1.7 | Experimental new `with_mocked_bindings()` and `local_mocked_bindings()` |
| 3.1.8 | also bind in the imports namespace and can mock S3 methods |
| 3.2.0 | taken out of experimental |
| 3.2.1 | can mock any object, not just functions |

On the declared minimum those files fail rather than skip. The calls pass
`.package` and rely on binding inside another package's namespace, which is
what 3.1.8 describes, so the floor is **3.2.0**: the first release where the
function is not experimental and that binding is in.

## A reported percentage was a sample, described as a census

`.warn_coarse_rmst_grid_builtin()` thins to at most 200 draws and 60 rows per
population before measuring the share of badly resolved draws, and its
documentation described the fraction without saying so. It now states the
subset and that it is taken by position rather than at random, so the same fit
reports the same number every time.

## Two sentences that could be read against their own meaning

**A geometric mean.** The data preparation article said one "is already on that
scale and is a different quantity". The first half reads as meeting the
requirement and the second withdraws it. `set_agd()` cannot tell the two
estimands apart, so this prose is the only guard there is; it now refuses the
geometric mean first and explains that its units are what make the mistake easy
to miss.

**Transport to a third population.** The method-choice article said to pass a
covariate distribution as `newdata` without naming what to pass it to.
`conditional_effects()` takes the same data frame and returns one effect per
profile, which is not a transported marginal effect. The sentence now names
`predict()` and `marginal_effects()` and states the difference.

## A fitting test with no backend guard

`test-survival-delayed-entry-aggregate.R` fits, and its only guard was
`skip_on_cran()`. `mlumr()` resolves `engine = NULL` through
`mlumr.stan_engine`, so a runner configured for cmdstanr without CmdStan
reaches compilation and errors instead of skipping. It now resolves the engine
and applies the guards `test-engine.R` uses.

## Verification

- Full suite: 3256 pass, 0 fail, 0 error.
- `tools::checkDocFiles()` reports nothing, before and after.
- `lintr` clean on both changed R files.
- No NEWS entries: the RMST helper and the two articles are new in this
  development cycle, the testthat floor is a test-time dependency, and the
  test change is test-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified how marginal and conditional effects differ when supplying decision-population data.
  - Explained that aggregate normal-family means and standard errors should use the arithmetic scale, including with log links.
  - Documented that built-in RMST-grid diagnostic warnings use reproducible subsets of posterior draws and population rows.

- **Tests**
  - Improved test handling when the configured statistical backend or required local tooling is unavailable.

- **Chores**
  - Updated the minimum suggested testing framework version to 3.2.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->