### PR TITLE
Stop refusing a survival plot for a time the caller asked for twice

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -415,9 +415,20 @@ geom_km <- function(data, treatments = NULL, population = NULL, marks = TRUE,
   df <- as.data.frame(x)
   key <- intersect(c("treatment", "population", "time"), names(df))
   if (!all(c("treatment", "population") %in% key)) return(invisible())
-  if (anyDuplicated(df[, key, drop = FALSE])) {
+  # A survival `times` keeps the caller's order and multiplicity, so one point
+  # asked for twice is two rows, and two times that snap to the same fitted
+  # neighbor are two rows as well. Neither is an ambiguity: they draw the same
+  # point twice. `requested_time` is what the caller asked for rather than what
+  # is drawn, so it is dropped before the rows are collapsed, or
+  # `times = c(2, 2.0001)` would survive as two rows and be refused.
+  #
+  # What remains after collapsing is one row per point that gets drawn, so a
+  # key that still repeats is two different values under one label, which is
+  # the thing that cannot be drawn.
+  drawn <- unique(df[, setdiff(names(df), "requested_time"), drop = FALSE])
+  if (anyDuplicated(drawn[, key, drop = FALSE])) {
     stop("This prediction has two series per population that share the ",
-         "treatment label '", df$treatment[1], "', so they cannot be drawn ",
+         "treatment label '", drawn$treatment[1], "', so they cannot be drawn ",
          "as separate curves. Give the two arms distinct treatment names in ",
          "set_ipd() / set_agd_surv() and refit.", call. = FALSE)
   }

--- a/R/plot.R
+++ b/R/plot.R
@@ -426,9 +426,14 @@ geom_km <- function(data, treatments = NULL, population = NULL, marks = TRUE,
   # key that still repeats is two different values under one label, which is
   # the thing that cannot be drawn.
   drawn <- unique(df[, setdiff(names(df), "requested_time"), drop = FALSE])
-  if (anyDuplicated(drawn[, key, drop = FALSE])) {
+  # `anyDuplicated()` gives the row where the key first repeats, which is the
+  # arm the message has to name. The first row of the frame is a different arm
+  # whenever the conflict is anywhere but the front, and renaming that one
+  # would not fix anything.
+  clash <- anyDuplicated(drawn[, key, drop = FALSE])
+  if (clash) {
     stop("This prediction has two series per population that share the ",
-         "treatment label '", drawn$treatment[1], "', so they cannot be drawn ",
+         "treatment label '", drawn$treatment[clash], "', so they cannot be drawn ",
          "as separate curves. Give the two arms distinct treatment names in ",
          "set_ipd() / set_agd_surv() and refit.", call. = FALSE)
   }

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -513,4 +513,14 @@ test_that("a time asked for twice is not an ambiguous pair of series", {
                             row("B", 2, 2, 0.7), row("B", 5, 5, 0.5))))
   # And the case the guard exists for is still refused: one label, two values.
   expect_false(accepts(rbind(row("A", 2, 2, 0.8), row("A", 2, 2, 0.7))))
+
+  # The message has to name the arm that clashes, not whichever arm happens to
+  # be first. Renaming a well-named front row would not fix anything.
+  msg <- tryCatch(
+    .reject_ambiguous_series(rbind(row("A", 2, 2, 0.9), row("B", 2, 2, 0.8),
+                                   row("C", 2, 2, 0.7), row("C", 2, 2, 0.6))),
+    error = function(e) conditionMessage(e)
+  )
+  expect_match(msg, "label 'C'", fixed = TRUE)
+  expect_false(grepl("label 'A'", msg, fixed = TRUE))
 })

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -482,3 +482,35 @@ test_that("the KM layer stays two curves without a population facet", {
   built <- ggplot2::ggplot_build(p)$data[[1]]
   expect_equal(length(unique(built$group)), 2L)
 })
+
+test_that("a time asked for twice is not an ambiguous pair of series", {
+  # A survival `times` keeps the caller's order and multiplicity, so
+  # `times = c(2, 2)` is two rows and two times that snap to one fitted
+  # neighbor are two rows as well. The ambiguity guard keyed on
+  # (treatment, population, time) and read either as two arms sharing a label,
+  # so plot(predict(fit, type = "survival", times = c(2, 2))) was refused with
+  # a message about naming the arms, which were already distinct.
+  row <- function(trt, req, tm, est) {
+    data.frame(treatment = trt, population = "index", requested_time = req,
+               time = tm, estimate = est, stringsAsFactors = FALSE)
+  }
+  accepts <- function(df) {
+    tryCatch({
+      .reject_ambiguous_series(df)
+      TRUE
+    }, error = function(e) FALSE)
+  }
+
+  # One point asked for twice, under two distinct labels.
+  expect_true(accepts(rbind(row("A", 2, 2, 0.8), row("A", 2, 2, 0.8),
+                            row("B", 2, 2, 0.7), row("B", 2, 2, 0.7))))
+  # Two different requests that snap to the same fitted time. These differ in
+  # `requested_time`, which is what was asked for rather than what is drawn.
+  expect_true(accepts(rbind(row("A", 2, 2, 0.8), row("A", 2.0001, 2, 0.8),
+                            row("B", 2, 2, 0.7), row("B", 2.0001, 2, 0.7))))
+  # The ordinary case stays accepted.
+  expect_true(accepts(rbind(row("A", 2, 2, 0.8), row("A", 5, 5, 0.6),
+                            row("B", 2, 2, 0.7), row("B", 5, 5, 0.5))))
+  # And the case the guard exists for is still refused: one label, two values.
+  expect_false(accepts(rbind(row("A", 2, 2, 0.8), row("A", 2, 2, 0.7))))
+})


### PR DESCRIPTION
Two changes on this branch meet badly.

A survival `times` now keeps the caller's order and multiplicity, so
`times = c(2, 2)` produces two rows, and two times that snap to the same fitted
neighbor produce two rows as well. `.reject_ambiguous_series()` keys on
`treatment`, `population` and `time` and refuses any duplicate of that key, so
it read both as two arms sharing a label.

Measured on the guard directly:

| frame | before | after |
|---|---|---|
| `times = c(2, 2)`, treatments A and B | **refused** | accepted |
| two requests snapping to one fitted time | **refused** | accepted |
| `times = c(2, 5)`, treatments A and B | accepted | accepted |
| one label, two different values | refused | refused |

The third row is ordinary use and the fourth is what the guard exists for. The
first two are plots of properly named arms, refused with a message telling the
user to give the arms distinct names in `set_ipd()` and refit, when the names
were already distinct and refitting would change nothing.

## The rule

Neither duplicate is an ambiguity: they draw the same point twice. The rows are
collapsed before the key is judged, and `requested_time` is dropped first
because it records what the caller asked for rather than what is drawn, so two
requests that snap to one time collapse too. What remains is one row per drawn
point, and a key that still repeats is two different values under one label,
which is the case that cannot be drawn and is still refused.

## Verification

- The four cases above are pinned as a table in `test-plot.R`, so a rule that
  fixes one and breaks another fails visibly.
- Reverting the collapse fails that test and nothing else.
- Full suite: 3260 pass, 0 fail, 0 error. `lintr` reports nothing new; the 28
  it reports on `test-plot.R` are all present on the base and outside this
  diff.

No NEWS entry: both the multiplicity retention and the ambiguity guard are new
in this development cycle and absent from 0.1.0, so this is a defect introduced
and fixed before release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Plotting now accepts repeated requests and different requested times that resolve to the same plotted point.
  - Genuine conflicts between distinct series sharing a treatment label continue to be rejected, with clearer error details.

- **Tests**
  - Added regression coverage for repeated requests, snapped times, multi-time series, and conflicting values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->