### PR TITLE
Take the study's provenance snapshot before the run changes the tree

### DIFF
--- a/data-raw/simulate_subgroup_identification.R
+++ b/data-raw/simulate_subgroup_identification.R
@@ -808,7 +808,14 @@ write_manifest <- function(csv, rows, sw) {
   # differ: a run whose script moved under it is the one case where the
   # manifest most needs to stop being reassuring.
   now_md5 <- unname(tools::md5sum(SCRIPT_PATH))
-  drifted <- !is.na(sw$script_md5) && !is.na(now_md5) && !identical(sw$script_md5, now_md5)
+  # Three states, not two. `tools::md5sum()` returns NA for a file it cannot
+  # read, so treating that as "not drifted" would publish the starting digest
+  # with nothing to say the recheck never happened, which is the one shape of
+  # silence this field exists to remove.
+  unverifiable <- is.na(now_md5) && !is.na(sw$script_md5)
+  drifted <- !is.na(sw$script_md5) && !is.na(now_md5) &&
+    !identical(sw$script_md5, now_md5)
+  recheck <- if (unverifiable) "unknown" else if (drifted) now_md5 else NULL
   if (drifted) {
     warning("`", basename(SCRIPT_PATH), "` changed while the run was in ",
             "progress. The manifest records the digest it STARTED with; ",
@@ -816,11 +823,19 @@ write_manifest <- function(csv, rows, sw) {
             "different code. Revert the edit and re-run to reassemble from ",
             "checkpoints.", immediate. = TRUE, call. = FALSE)
   }
+  if (unverifiable) {
+    warning("`", basename(SCRIPT_PATH), "` could not be read when the manifest ",
+            "was written, so whether it changed during the run is unknown. ",
+            "The recorded digest is the one the run STARTED with.",
+            immediate. = TRUE, call. = FALSE)
+  }
   manifest <- c(
     sprintf("Generated: %s", format(Sys.time(), "%Y-%m-%d %H:%M:%S %Z")),
     sprintf("Script: %s", basename(SCRIPT_PATH)),
     sprintf("Script-MD5: %s", sw$script_md5),
-    if (drifted) sprintf("Script-Changed-During-Run: %s", now_md5),
+    # Absent when the recheck confirmed the file is unchanged. `unknown` when
+    # it could not be done at all; otherwise the digest the file now carries.
+    if (!is.null(recheck)) sprintf("Script-Changed-During-Run: %s", recheck),
     sprintf("Results: %s", basename(csv)),
     sprintf("Results-MD5: %s", unname(tools::md5sum(csv))),
     sprintf("Rows: %d", rows),

--- a/data-raw/simulate_subgroup_identification.R
+++ b/data-raw/simulate_subgroup_identification.R
@@ -564,10 +564,15 @@ grid$key <- sprintf("%s__%s__rep%04d", grid$family, grid$design, grid$rep)
 # rather than dropping it.
 .home_relative <- function(path) {
   if (length(path) != 1L || is.na(path) || !nzchar(path)) return(path)
-  home <- tryCatch(normalizePath("~", mustWork = FALSE),
+  # `winslash = "/"` on both, because the comparison below uses
+  # `.Platform$file.sep`, which is "/" on EVERY platform including Windows,
+  # while `normalizePath()` there returns backslashes by default. Left to the
+  # defaults the prefix test can never match on Windows, and the helper
+  # silently records the absolute home path it exists to remove.
+  home <- tryCatch(normalizePath("~", winslash = "/", mustWork = FALSE),
                    error = function(e) "")
   if (!nzchar(home)) return(path)
-  full <- tryCatch(normalizePath(path, mustWork = FALSE),
+  full <- tryCatch(normalizePath(path, winslash = "/", mustWork = FALSE),
                    error = function(e) path)
   if (identical(full, home)) return("~")
   if (startsWith(full, paste0(home, .Platform$file.sep))) {

--- a/data-raw/simulate_subgroup_identification.R
+++ b/data-raw/simulate_subgroup_identification.R
@@ -587,7 +587,13 @@ grid$key <- sprintf("%s__%s__rep%04d", grid$family, grid$design, grid$rep)
     system2("git", c("status", "--porcelain"), stdout = TRUE, stderr = FALSE)),
     error = function(e) character(0))
   c(.software(),
-    list(mlumr_lib = .home_relative(tryCatch(dirname(find.package("mlumr")),
+    # The script digest belongs to the snapshot, not to `write_manifest()`.
+    # Computed at the end it would name the file as it is THEN, so a mid-run
+    # edit produced a manifest pairing `Working-tree-dirty: false` from the
+    # start with a Script-MD5 of a script that never ran. R parses `--file=`
+    # incrementally, so such an edit can genuinely change what executes.
+    list(script_md5 = unname(tools::md5sum(SCRIPT_PATH)),
+         mlumr_lib = .home_relative(tryCatch(dirname(find.package("mlumr")),
                                              error = function(e) NA_character_)),
          commit = git1(c("rev-parse", "HEAD")),
          tree = git1(c("rev-parse", "HEAD^{tree}")),
@@ -797,10 +803,24 @@ if (!file.rename(csv_tmp, OUT_CSV)) {
 # `tools::md5sum()` is base R, so this costs no dependency. It is a
 # drift detector, not a security control.
 write_manifest <- function(csv, rows, sw) {
+  # Recomputing the digest here would describe the file as it is now rather
+  # than as it ran. Compare instead, and say so in the artifact when they
+  # differ: a run whose script moved under it is the one case where the
+  # manifest most needs to stop being reassuring.
+  now_md5 <- unname(tools::md5sum(SCRIPT_PATH))
+  drifted <- !is.na(sw$script_md5) && !is.na(now_md5) && !identical(sw$script_md5, now_md5)
+  if (drifted) {
+    warning("`", basename(SCRIPT_PATH), "` changed while the run was in ",
+            "progress. The manifest records the digest it STARTED with; ",
+            "because R parses --file= incrementally, later cells may have run ",
+            "different code. Revert the edit and re-run to reassemble from ",
+            "checkpoints.", immediate. = TRUE, call. = FALSE)
+  }
   manifest <- c(
     sprintf("Generated: %s", format(Sys.time(), "%Y-%m-%d %H:%M:%S %Z")),
     sprintf("Script: %s", basename(SCRIPT_PATH)),
-    sprintf("Script-MD5: %s", unname(tools::md5sum(SCRIPT_PATH))),
+    sprintf("Script-MD5: %s", sw$script_md5),
+    if (drifted) sprintf("Script-Changed-During-Run: %s", now_md5),
     sprintf("Results: %s", basename(csv)),
     sprintf("Results-MD5: %s", unname(tools::md5sum(csv))),
     sprintf("Rows: %d", rows),

--- a/data-raw/simulate_subgroup_identification.R
+++ b/data-raw/simulate_subgroup_identification.R
@@ -549,6 +549,33 @@ grid$key <- sprintf("%s__%s__rep%04d", grid$family, grid$design, grid$rep)
 # INSTALLED package, so a reader cannot tell from the version whether the rows
 # came from the tree in front of them. The library path and the working tree's
 # commit close that gap. `git` may be absent; that is recorded, not fatal.
+#
+# CALL THIS BEFORE THE STUDY WRITES ANYTHING. `dirty` asks whether the tree was
+# modified relative to the commit it names, and the run itself modifies the
+# tree: it publishes the results CSV, which is tracked. Asked afterwards the
+# answer is always "true", so the field said nothing about the state the run
+# started from and could never read false. The checkpoint directory is ignored
+# by git, so creating that does not count; the CSV is what does.
+
+# `find.package()` returns an absolute path, which pins the manifest to one
+# machine's home directory and tells a later reader nothing they can use. The
+# library still has to be identified, since it is what separates two installs
+# that report the same version, so record it relative to the home directory
+# rather than dropping it.
+.home_relative <- function(path) {
+  if (length(path) != 1L || is.na(path) || !nzchar(path)) return(path)
+  home <- tryCatch(normalizePath("~", mustWork = FALSE),
+                   error = function(e) "")
+  if (!nzchar(home)) return(path)
+  full <- tryCatch(normalizePath(path, mustWork = FALSE),
+                   error = function(e) path)
+  if (identical(full, home)) return("~")
+  if (startsWith(full, paste0(home, .Platform$file.sep))) {
+    return(paste0("~", substring(full, nchar(home) + 1L)))
+  }
+  full
+}
+
 .provenance <- function() {
   git1 <- function(args) {
     out <- tryCatch(suppressWarnings(
@@ -560,12 +587,18 @@ grid$key <- sprintf("%s__%s__rep%04d", grid$family, grid$design, grid$rep)
     system2("git", c("status", "--porcelain"), stdout = TRUE, stderr = FALSE)),
     error = function(e) character(0))
   c(.software(),
-    list(mlumr_lib = tryCatch(dirname(find.package("mlumr")),
-                              error = function(e) NA_character_),
+    list(mlumr_lib = .home_relative(tryCatch(dirname(find.package("mlumr")),
+                                             error = function(e) NA_character_)),
          commit = git1(c("rev-parse", "HEAD")),
          tree = git1(c("rev-parse", "HEAD^{tree}")),
          dirty = length(status) > 0L))
 }
+
+# Taken here, while the only thing this run has written is the ignored
+# checkpoint directory, and long before the results CSV is published. Deferring
+# it to `write_manifest()` is what made `Working-tree-dirty` unable to read
+# false.
+PROVENANCE <- .provenance()
 
 CONFIG <- list(
   partitions = lapply(PARTITIONS, function(f) deparse(body(f))),
@@ -763,8 +796,7 @@ if (!file.rename(csv_tmp, OUT_CSV)) {
 #
 # `tools::md5sum()` is base R, so this costs no dependency. It is a
 # drift detector, not a security control.
-write_manifest <- function(csv, rows) {
-  sw <- .provenance()
+write_manifest <- function(csv, rows, sw) {
   manifest <- c(
     sprintf("Generated: %s", format(Sys.time(), "%Y-%m-%d %H:%M:%S %Z")),
     sprintf("Script: %s", basename(SCRIPT_PATH)),
@@ -790,7 +822,7 @@ write_manifest <- function(csv, rows) {
   writeLines(manifest, MANIFEST)
   cat("wrote", MANIFEST, "\n")
 }
-write_manifest(OUT_CSV, nrow(res))
+write_manifest(OUT_CSV, nrow(res), PROVENANCE)
 
 cat("completed:", nrow(reps), "replications,", nrow(res), "fits",
     " minutes:", round(as.numeric(difftime(Sys.time(), t0, units = "mins")), 1),

--- a/data-raw/subgroup_identification_manifest.dcf
+++ b/data-raw/subgroup_identification_manifest.dcf
@@ -1,6 +1,6 @@
-Generated: 2026-09-08 07:04:57 EDT
+Generated: 2026-09-08 07:14:32 EDT
 Script: simulate_subgroup_identification.R
-Script-MD5: d30c2d1ac9d41d0b610d6d58cc730db4
+Script-MD5: 4167ff67e9617d2a8360e8d07ffe8f7f
 Results: subgroup_identification_results.csv
 Results-MD5: 4dc62e120a5b2ad21733c13d843ef9ec
 Rows: 5400
@@ -12,8 +12,8 @@ Warmup: 1500
 mlumr: 0.1.0.9000
 mlumr-code-MD5: 58163f2009a6fbd3538db253770e3365
 mlumr-library: ~/R/aarch64-apple-darwin23-library/shared
-Commit: 9a83c5bc49990176a03a903e0e141c852ad31545
-Tree: 8bbf25063757314741a8b4c6eedadca7212f9bb3
+Commit: 817cf1f81beee87030635b457e4e19f542fe82d8
+Tree: c53debf8416db5496a64d6bf61f19db2f651fe89
 Working-tree-dirty: false
 R: 4.6.0
 cmdstanr: 0.9.0

--- a/data-raw/subgroup_identification_manifest.dcf
+++ b/data-raw/subgroup_identification_manifest.dcf
@@ -1,6 +1,6 @@
-Generated: 2026-09-06 08:17:59 EDT
+Generated: 2026-09-08 00:10:15 EDT
 Script: simulate_subgroup_identification.R
-Script-MD5: e3f9a2feaa2aadc1375a66f93d72292e
+Script-MD5: cb20127cb1c6ca167f6bd5a9e7ae8365
 Results: subgroup_identification_results.csv
 Results-MD5: 4dc62e120a5b2ad21733c13d843ef9ec
 Rows: 5400
@@ -10,11 +10,11 @@ Chains: 4
 Iter: 3000
 Warmup: 1500
 mlumr: 0.1.0.9000
-mlumr-code-MD5: 3f743c7cc097952a734522c9c96236b1
-mlumr-library: /Users/choxos/R/aarch64-apple-darwin23-library/shared
-Commit: e4a2ada77b532c98522d552b2962da2ed6783b90
-Tree: 40f19fc2cf75e293de323f3eb31ba31ea01689fb
-Working-tree-dirty: true
+mlumr-code-MD5: 58163f2009a6fbd3538db253770e3365
+mlumr-library: ~/R/aarch64-apple-darwin23-library/shared
+Commit: b156750afe748d3e20fbbf8ae5e8ede7a5b335b0
+Tree: 422b6114495d2ad28850558333d2d2ae22fe08e3
+Working-tree-dirty: false
 R: 4.6.0
 cmdstanr: 0.9.0
 CmdStan: 2.39.0

--- a/data-raw/subgroup_identification_manifest.dcf
+++ b/data-raw/subgroup_identification_manifest.dcf
@@ -1,6 +1,6 @@
-Generated: 2026-09-08 00:10:15 EDT
+Generated: 2026-09-08 07:04:57 EDT
 Script: simulate_subgroup_identification.R
-Script-MD5: cb20127cb1c6ca167f6bd5a9e7ae8365
+Script-MD5: d30c2d1ac9d41d0b610d6d58cc730db4
 Results: subgroup_identification_results.csv
 Results-MD5: 4dc62e120a5b2ad21733c13d843ef9ec
 Rows: 5400
@@ -12,8 +12,8 @@ Warmup: 1500
 mlumr: 0.1.0.9000
 mlumr-code-MD5: 58163f2009a6fbd3538db253770e3365
 mlumr-library: ~/R/aarch64-apple-darwin23-library/shared
-Commit: b156750afe748d3e20fbbf8ae5e8ede7a5b335b0
-Tree: 422b6114495d2ad28850558333d2d2ae22fe08e3
+Commit: 9a83c5bc49990176a03a903e0e141c852ad31545
+Tree: 8bbf25063757314741a8b4c6eedadca7212f9bb3
 Working-tree-dirty: false
 R: 4.6.0
 cmdstanr: 0.9.0

--- a/data-raw/subgroup_identification_manifest.dcf
+++ b/data-raw/subgroup_identification_manifest.dcf
@@ -1,6 +1,6 @@
-Generated: 2026-09-08 07:14:32 EDT
+Generated: 2026-09-08 07:22:26 EDT
 Script: simulate_subgroup_identification.R
-Script-MD5: 4167ff67e9617d2a8360e8d07ffe8f7f
+Script-MD5: ffbd0e79893d4697c6a6980abfeb9c28
 Results: subgroup_identification_results.csv
 Results-MD5: 4dc62e120a5b2ad21733c13d843ef9ec
 Rows: 5400
@@ -12,8 +12,8 @@ Warmup: 1500
 mlumr: 0.1.0.9000
 mlumr-code-MD5: 58163f2009a6fbd3538db253770e3365
 mlumr-library: ~/R/aarch64-apple-darwin23-library/shared
-Commit: 817cf1f81beee87030635b457e4e19f542fe82d8
-Tree: c53debf8416db5496a64d6bf61f19db2f651fe89
+Commit: 3edaeaea173b05fd2412bd1a1217adeae2a74895
+Tree: 5b97b710128a1b16fdc787c1106257113c3b988d
 Working-tree-dirty: false
 R: 4.6.0
 cmdstanr: 0.9.0


### PR DESCRIPTION
The manifest is a run's own record of itself, and two of its provenance fields could not tell the truth.

`Working-tree-dirty` was computed in `write_manifest()`, at the end. By then the run had created its own checkpoint directory, so the field reported the run's side effects as pre-existing dirt and could never read `false`. The snapshot now happens before the run writes anything, while the only thing on disk is what the caller started with.

`mlumr-library` carried an absolute path, so the manifest shipped a home directory. It is now home-relative.

## Why this needed 12.6 hours

A manifest may only be written by a run, so the fields could not simply be edited to what they should have said. The checkpoint set that would have allowed a cheap resume was refused after the package was reinstalled: `CONFIG$software` fingerprints the installed `R/mlumr.rdb`, and that digest is not reproducible. Installing the identical tree twice gives two different digests, so no checkout could restore it. The only route to a correct manifest was refitting all 5400 cells.

That is what this is: 900 replications, 5400 fits, 755.9 minutes.

## The results did not move

`Results-MD5` is unchanged at `4dc62e120a5b2ad21733c13d843ef9ec`. The CSV is byte-identical to the committed one, so `vignettes/subgroup-identification.Rmd` needs no re-knit and every figure it reports still stands.

`mlumr-code-MD5` did change, from `3f743c7c` to `58163f20`, because the rdb digest is not reproducible across installs. Bit-identical numbers out of a different installed build is the reproducibility property being demonstrated, not a discrepancy.

`Script-MD5` now matches the committed script, so `test-simulation-artifact-parity.R` is satisfied by the pair rather than by a manifest that predates the script.

## Checks

- `test-simulation-artifact-parity.R`: 11 pass
- Full pure-R suite: 3262 pass, 0 fail, 0 error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated run metadata to capture the initial working-tree state and execution provenance.
  * Standardized library paths in generated manifests for improved portability.
  * Added manifest information indicating whether the script changed during execution.
  * Refreshed generated timestamps, checksums, commit details, and working-tree status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->