### PR TITLE
Count the diagnostics that are missing, and stop explaining why

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,11 +7,20 @@
   all, and it was filtered out before the maximum was taken, so a fit holding
   `1.001` and `Inf` reported a maximum Rhat of 1.001 and raised no warning.
   Infinite values now reach the worst-case statistic, in `check_diagnostics()`
-  and in the printed fit summary alike. A genuinely missing value, which a
-  constant generated quantity legitimately has, is counted and reported instead
-  of being dropped from a statistic that calls itself the maximum. Divergence
-  and treedepth counts the backend did not supply were read as zero, which is
-  the answer that says the sampler behaved; they are now reported as unknown.
+  and in the printed fit summary alike. A genuinely missing value is counted
+  and reported instead of being dropped from a statistic that calls itself the
+  maximum, and the report names the parameters it could not check. It does not
+  name a cause: a constant generated quantity has no Rhat, and neither does a
+  parameter whose chains are each stuck at a different constant or whose draws
+  are not finite, and nothing here has looked at the draws to tell those apart.
+  A column that is absent, or present but not numeric, is counted the same way.
+  `c(NA, NA)` is a logical vector in R, which is what a backend writes into a
+  column it never filled, and reading it as zero diagnostics rather than as two
+  missing ones meant the summary printed no line at all. Divergence and
+  treedepth counts the backend did not supply were read as zero, which is the
+  answer that says the sampler behaved; they are now reported as unknown, as is
+  a count that is not a whole number or is past the integer range, both of
+  which `as.integer()` had been turning into a clean zero or a silent `NA`.
 
 * **`mlumr_forest()` takes its null from the effect rather than from the
   axis.** The reference line defaulted to `1` when `log_x = TRUE` and `0`

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -1001,8 +1001,10 @@ check_diagnostics <- function(fit) {
   # warning. Keep every value that is a number; a missing one is a parameter
   # without an Rhat, which is counted and reported rather than silently
   # excluded from a statistic that calls itself the maximum.
-  rhat <- .usable_diagnostic_values(fit$summary$Rhat)
-  .report_missing_diagnostics(rhat, "Rhat", "convergence")
+  n_par <- nrow(fit$summary)
+  rhat <- .usable_diagnostic_values(fit$summary$Rhat, n_par)
+  .report_missing_diagnostics(rhat, "Rhat", "convergence",
+                              fit$summary$variable)
   if (length(rhat$values) > 0L) {
     max_rhat <- max(rhat$values)
     if (max_rhat > 1.05) {
@@ -1018,8 +1020,9 @@ check_diagnostics <- function(fit) {
     }
   }
 
-  ess <- .usable_diagnostic_values(fit$summary$n_eff)
-  .report_missing_diagnostics(ess, "Bulk ESS", "effective sample size")
+  ess <- .usable_diagnostic_values(fit$summary$n_eff, n_par)
+  .report_missing_diagnostics(ess, "Bulk ESS", "effective sample size",
+                              fit$summary$variable)
   if (length(ess$values) > 0L) {
     min_ess <- min(ess$values)
     if (min_ess < 400) {
@@ -1120,18 +1123,32 @@ check_diagnostics <- function(fit) {
 #' worst-case statistic that could not report the worst case, and reported a
 #' benign number in its place.
 #'
-#' @param x A summary column.
+#' A column that is absent, or present but not numeric, is not zero
+#' diagnostics either. `c(NA, NA)` is a LOGICAL vector in R, so a backend that
+#' wrote missing values into a column it never filled produced two unavailable
+#' diagnostics, and this reported none: `n_total` came back 0, the reporter
+#' below says nothing when the total is 0, and the summary printed no line at
+#' all. `n_expected` is what the caller knows the count should be, normally the
+#' number of rows in the summary, so an absent column is reported as entirely
+#' missing rather than as an empty population of parameters.
+#'
+#' @param x A summary column, possibly `NULL`.
+#' @param n_expected How many parameters should have had a diagnostic. Defaults
+#'   to the length of `x`, which is right whenever the column is present.
 #' @return A list with `values` (every number, infinities included) and
 #'   `n_missing` / `n_total` counts.
 #' @keywords internal
-.usable_diagnostic_values <- function(x) {
+.usable_diagnostic_values <- function(x, n_expected = length(x)) {
   if (!is.numeric(x)) {
-    return(list(values = numeric(), n_missing = 0L, n_total = 0L))
+    n <- as.integer(max(n_expected, length(x)))
+    return(list(values = numeric(), n_missing = n, n_total = n,
+                missing_idx = seq_len(n)))
   }
   keep <- !is.na(x)
   list(values = x[keep],
        n_missing = sum(!keep),
-       n_total = length(x))
+       n_total = length(x),
+       missing_idx = which(!keep))
 }
 
 
@@ -1141,18 +1158,44 @@ check_diagnostics <- function(fit) {
 #' like a clean one. This follows the tail-ESS block below, which already
 #' counts and reports what it could not check.
 #'
+#' The message names the OUTCOME and not a cause. A missing diagnostic has
+#' several, and nothing here has looked at the draws to tell them apart: a
+#' quantity that is constant by construction has no Rhat, and neither does one
+#' whose chains are each stuck at a different constant, or whose draws are not
+#' finite. Calling the benign one "the usual reason" turned an unchecked
+#' parameter into a reassurance. Which parameters they were is something this
+#' does know, so it says that instead.
+#'
 #' @param d A [.usable_diagnostic_values()] result.
 #' @param label Diagnostic name for the message.
 #' @param what What the diagnostic measures, for the message.
+#' @param variables Parameter names in the same order as the column, or `NULL`.
 #' @return `NULL`, invisibly.
 #' @keywords internal
-.report_missing_diagnostics <- function(d, label, what) {
+.report_missing_diagnostics <- function(d, label, what, variables = NULL) {
   if (d$n_missing > 0L && d$n_total > 0L) {
+    named <- ""
+    if (!is.null(variables) && length(variables) == d$n_total) {
+      missing_names <- utils::head(as.character(variables)[d$missing_idx], 6L)
+      if (length(missing_names)) {
+        named <- paste0(" Unavailable for: ",
+                        paste(missing_names, collapse = ", "),
+                        if (d$n_missing > length(missing_names)) {
+                          sprintf(" and %d more.", d$n_missing -
+                                    length(missing_names))
+                        } else {
+                          "."
+                        })
+      }
+    }
     message(sprintf(
       paste0("%s is unavailable for %d of %d parameter(s), which were not ",
-             "checked for %s; the remaining %d were. A constant generated ",
-             "quantity has no %s and is the usual reason."),
-      label, d$n_missing, d$n_total, what, d$n_total - d$n_missing, label
+             "checked for %s; the remaining %d were.%s A diagnostic that ",
+             "could not be computed is not one that came out well: it is ",
+             "legitimately absent for a quantity that is constant across ",
+             "every draw, and equally absent when the chains are stuck or the ",
+             "draws are not finite."),
+      label, d$n_missing, d$n_total, what, d$n_total - d$n_missing, named
     ))
   }
   invisible(NULL)
@@ -1210,11 +1253,17 @@ check_diagnostics <- function(fit) {
 #' answer that says the sampler behaved, so an unreported count has to stay
 #' unknown instead.
 #'
+#' A count is a whole number, and `as.integer()` truncates rather than
+#' refusing: 0.5 became 0, which is exactly the value that says the sampler
+#' behaved, and a count past the integer range became `NA` with a coercion
+#' warning. Neither is a count, so both are reported as unknown.
+#'
 #' @param x The recorded count.
 #' @return A non-negative integer, or `NA_integer_` when unknown.
 #' @keywords internal
 .transition_count <- function(x) {
-  if (!is.numeric(x) || length(x) != 1L || !is.finite(x) || x < 0) {
+  if (!is.numeric(x) || length(x) != 1L || !is.finite(x) || x < 0 ||
+        x != trunc(x) || x > .Machine$integer.max) {
     return(NA_integer_)
   }
   as.integer(x)

--- a/R/mlumr_class.R
+++ b/R/mlumr_class.R
@@ -1,6 +1,24 @@
 
 
 #' @method print mlumr_fit
+#' Select summary columns that are actually there
+#'
+#' The printed summary reports "unavailable" for a diagnostic its column does
+#' not carry, and then the tables below it selected `"Rhat"` by name anyway, so
+#' a fit without that column announced the gap and died of it one line later
+#' with "undefined columns selected". Normal backend output always has the
+#' column; a legacy or hand-built fit is exactly the case the unavailable line
+#' exists for, so it has to survive the rest of the method too.
+#'
+#' @param df A summary data frame.
+#' @param cols Column names to take, in order.
+#' @return `df` with those of `cols` it has.
+#' @keywords internal
+.summary_columns <- function(df, cols) {
+  df[, intersect(cols, names(df)), drop = FALSE]
+}
+
+
 #' @export
 print.mlumr_fit <- function(x, ...) {
   cat("ML-UMR Fit\n")
@@ -68,7 +86,9 @@ print.mlumr_fit <- function(x, ...) {
   idx <- x$summary$variable %in% params
   if (any(idx)) {
     cat("Key Parameters:\n")
-    sub_df <- x$summary[idx, c("variable", "mean", "sd", "2.5%", "97.5%", "Rhat")]
+    sub_df <- .summary_columns(x$summary[idx, , drop = FALSE],
+                             c("variable", "mean", "sd", "2.5%",
+                               "97.5%", "Rhat"))
     print(sub_df, row.names = FALSE)
     # `delta_conditional` is mu_index - mu_comparator, which is eta_index(x) -
     # eta_comparator(x) evaluated at x = 0. Two separate conditions matter and
@@ -185,7 +205,8 @@ summary.mlumr_fit <- function(object, ...) {
   scale_label <- paste0(link_label, " scale")
   cat(sprintf("Intercepts (%s):\n", scale_label))
   mu_idx <- grep("^mu_", object$summary$variable)
-  print(object$summary[mu_idx, c("variable", "mean", "sd", "2.5%", "97.5%", "Rhat")],
+  print(.summary_columns(object$summary[mu_idx, , drop = FALSE],
+                       c("variable", "mean", "sd", "2.5%", "97.5%", "Rhat")),
         row.names = FALSE)
 
   # Residual SD (normal only)
@@ -193,7 +214,8 @@ summary.mlumr_fit <- function(object, ...) {
     sigma_idx <- which(object$summary$variable == "sigma")
     if (length(sigma_idx) > 0) {
       cat("\nResidual SD:\n")
-      print(object$summary[sigma_idx, c("variable", "mean", "sd", "2.5%", "97.5%", "Rhat")],
+      print(.summary_columns(object$summary[sigma_idx, , drop = FALSE],
+                       c("variable", "mean", "sd", "2.5%", "97.5%", "Rhat")),
             row.names = FALSE)
     }
   }
@@ -209,8 +231,9 @@ summary.mlumr_fit <- function(object, ...) {
     # Relabel beta[1] as beta[age] for readability. The underlying `variable`
     # strings in object$summary are untouched, so code indexing by name keeps
     # working; only this printed copy is relabeled.
-    beta_df <- object$summary[beta_idx,
-                              c("variable", "mean", "sd", "2.5%", "97.5%", "Rhat")]
+    beta_df <- .summary_columns(
+      object$summary[beta_idx, , drop = FALSE],
+      c("variable", "mean", "sd", "2.5%", "97.5%", "Rhat"))
     print(.label_beta_rows(beta_df, object$data$covariates), row.names = FALSE)
 
   }
@@ -243,9 +266,10 @@ summary.mlumr_fit <- function(object, ...) {
                          "sigma_smooth", "sigma_smooth[1]", "sigma_smooth[2]"))
     if (length(aux_idx) > 0) {
       cat("\nShape / smoothing parameters:\n")
-      print(object$summary[aux_idx,
-                           c("variable", "mean", "sd", "2.5%", "97.5%", "Rhat")],
-            row.names = FALSE)
+      print(.summary_columns(
+        object$summary[aux_idx, , drop = FALSE],
+        c("variable", "mean", "sd", "2.5%", "97.5%", "Rhat")),
+        row.names = FALSE)
     }
   }
 

--- a/R/mlumr_class.R
+++ b/R/mlumr_class.R
@@ -86,9 +86,8 @@ print.mlumr_fit <- function(x, ...) {
   idx <- x$summary$variable %in% params
   if (any(idx)) {
     cat("Key Parameters:\n")
-    sub_df <- .summary_columns(x$summary[idx, , drop = FALSE],
-                             c("variable", "mean", "sd", "2.5%",
-                               "97.5%", "Rhat"))
+    keep_cols <- c("variable", "mean", "sd", "2.5%", "97.5%", "Rhat")
+    sub_df <- .summary_columns(x$summary[idx, , drop = FALSE], keep_cols)
     print(sub_df, row.names = FALSE)
     # `delta_conditional` is mu_index - mu_comparator, which is eta_index(x) -
     # eta_comparator(x) evaluated at x = 0. Two separate conditions matter and
@@ -205,8 +204,8 @@ summary.mlumr_fit <- function(object, ...) {
   scale_label <- paste0(link_label, " scale")
   cat(sprintf("Intercepts (%s):\n", scale_label))
   mu_idx <- grep("^mu_", object$summary$variable)
-  print(.summary_columns(object$summary[mu_idx, , drop = FALSE],
-                       c("variable", "mean", "sd", "2.5%", "97.5%", "Rhat")),
+  keep_cols <- c("variable", "mean", "sd", "2.5%", "97.5%", "Rhat")
+  print(.summary_columns(object$summary[mu_idx, , drop = FALSE], keep_cols),
         row.names = FALSE)
 
   # Residual SD (normal only)
@@ -215,7 +214,7 @@ summary.mlumr_fit <- function(object, ...) {
     if (length(sigma_idx) > 0) {
       cat("\nResidual SD:\n")
       print(.summary_columns(object$summary[sigma_idx, , drop = FALSE],
-                       c("variable", "mean", "sd", "2.5%", "97.5%", "Rhat")),
+                             keep_cols),
             row.names = FALSE)
     }
   }
@@ -231,9 +230,8 @@ summary.mlumr_fit <- function(object, ...) {
     # Relabel beta[1] as beta[age] for readability. The underlying `variable`
     # strings in object$summary are untouched, so code indexing by name keeps
     # working; only this printed copy is relabeled.
-    beta_df <- .summary_columns(
-      object$summary[beta_idx, , drop = FALSE],
-      c("variable", "mean", "sd", "2.5%", "97.5%", "Rhat"))
+    beta_df <- .summary_columns(object$summary[beta_idx, , drop = FALSE],
+                                keep_cols)
     print(.label_beta_rows(beta_df, object$data$covariates), row.names = FALSE)
 
   }
@@ -266,10 +264,9 @@ summary.mlumr_fit <- function(object, ...) {
                          "sigma_smooth", "sigma_smooth[1]", "sigma_smooth[2]"))
     if (length(aux_idx) > 0) {
       cat("\nShape / smoothing parameters:\n")
-      print(.summary_columns(
-        object$summary[aux_idx, , drop = FALSE],
-        c("variable", "mean", "sd", "2.5%", "97.5%", "Rhat")),
-        row.names = FALSE)
+      aux_df <- .summary_columns(object$summary[aux_idx, , drop = FALSE],
+                                 keep_cols)
+      print(aux_df, row.names = FALSE)
     }
   }
 

--- a/R/mlumr_class.R
+++ b/R/mlumr_class.R
@@ -158,18 +158,27 @@ summary.mlumr_fit <- function(object, ...) {
       .diagnostic_display(.transition_count(object$diagnostics$n_divergent)), "\n")
   cat("  Max treedepth hits:",
       .diagnostic_display(.transition_count(object$diagnostics$n_max_treedepth)), "\n")
-  if (!is.null(object$summary$Rhat)) {
-    rhat <- .usable_diagnostic_values(object$summary$Rhat)
-    cat("  Max Rhat:",
-        if (length(rhat$values)) .format_diagnostic(max(rhat$values)) else "unavailable",
-        .missing_suffix(rhat), "\n")
-  }
-  if (!is.null(object$summary$n_eff)) {
-    ess <- .usable_diagnostic_values(object$summary$n_eff)
-    cat("  Min ESS:",
-        if (length(ess$values)) .format_diagnostic(min(ess$values)) else "unavailable",
-        .missing_suffix(ess), "\n")
-  }
+  # Guarding on the column being present hid the case worth showing. A summary
+  # with no Rhat column at all printed no Rhat line, which reads as a fit that
+  # was not asked about rather than one that cannot answer. Ask for the count
+  # the summary should have and let the line say "unavailable".
+  n_par <- nrow(object$summary)
+  rhat <- .usable_diagnostic_values(object$summary$Rhat, n_par)
+  cat("  Max Rhat:",
+      if (length(rhat$values)) {
+        .format_diagnostic(max(rhat$values))
+      } else {
+        "unavailable"
+      },
+      .missing_suffix(rhat), "\n")
+  ess <- .usable_diagnostic_values(object$summary$n_eff, n_par)
+  cat("  Min ESS:",
+      if (length(ess$values)) {
+        .format_diagnostic(min(ess$values))
+      } else {
+        "unavailable"
+      },
+      .missing_suffix(ess), "\n")
   cat("\n")
 
   # Intercepts

--- a/man/dot-report_missing_diagnostics.Rd
+++ b/man/dot-report_missing_diagnostics.Rd
@@ -4,7 +4,7 @@
 \alias{.report_missing_diagnostics}
 \title{Say how many parameters had no diagnostic, rather than dropping them}
 \usage{
-.report_missing_diagnostics(d, label, what)
+.report_missing_diagnostics(d, label, what, variables = NULL)
 }
 \arguments{
 \item{d}{A \code{\link[=.usable_diagnostic_values]{.usable_diagnostic_values()}} result.}
@@ -12,6 +12,8 @@
 \item{label}{Diagnostic name for the message.}
 
 \item{what}{What the diagnostic measures, for the message.}
+
+\item{variables}{Parameter names in the same order as the column, or \code{NULL}.}
 }
 \value{
 \code{NULL}, invisibly.
@@ -20,5 +22,14 @@
 A partly-missing column checked on its present entries alone reads exactly
 like a clean one. This follows the tail-ESS block below, which already
 counts and reports what it could not check.
+}
+\details{
+The message names the OUTCOME and not a cause. A missing diagnostic has
+several, and nothing here has looked at the draws to tell them apart: a
+quantity that is constant by construction has no Rhat, and neither does one
+whose chains are each stuck at a different constant, or whose draws are not
+finite. Calling the benign one "the usual reason" turned an unchecked
+parameter into a reassurance. Which parameters they were is something this
+does know, so it says that instead.
 }
 \keyword{internal}

--- a/man/dot-transition_count.Rd
+++ b/man/dot-transition_count.Rd
@@ -18,4 +18,10 @@ separately. Divergence and treedepth counts have no such guard, and 0 is the
 answer that says the sampler behaved, so an unreported count has to stay
 unknown instead.
 }
+\details{
+A count is a whole number, and \code{as.integer()} truncates rather than
+refusing: 0.5 became 0, which is exactly the value that says the sampler
+behaved, and a count past the integer range became \code{NA} with a coercion
+warning. Neither is a count, so both are reported as unknown.
+}
 \keyword{internal}

--- a/man/dot-usable_diagnostic_values.Rd
+++ b/man/dot-usable_diagnostic_values.Rd
@@ -4,10 +4,13 @@
 \alias{.usable_diagnostic_values}
 \title{Split a diagnostic column into usable values and missing ones}
 \usage{
-.usable_diagnostic_values(x)
+.usable_diagnostic_values(x, n_expected = length(x))
 }
 \arguments{
-\item{x}{A summary column.}
+\item{x}{A summary column, possibly \code{NULL}.}
+
+\item{n_expected}{How many parameters should have had a diagnostic. Defaults
+to the length of \code{x}, which is right whenever the column is present.}
 }
 \value{
 A list with \code{values} (every number, infinities included) and
@@ -21,5 +24,15 @@ parameter that has no diagnostic at all, which happens legitimately for a
 quantity that is constant across every draw. Filtering both away left a
 worst-case statistic that could not report the worst case, and reported a
 benign number in its place.
+}
+\details{
+A column that is absent, or present but not numeric, is not zero
+diagnostics either. \code{c(NA, NA)} is a LOGICAL vector in R, so a backend that
+wrote missing values into a column it never filled produced two unavailable
+diagnostics, and this reported none: \code{n_total} came back 0, the reporter
+below says nothing when the total is 0, and the summary printed no line at
+all. \code{n_expected} is what the caller knows the count should be, normally the
+number of rows in the summary, so an absent column is reported as entirely
+missing rather than as an empty population of parameters.
 }
 \keyword{internal}

--- a/tests/testthat/test-diagnostics-worst-case.R
+++ b/tests/testthat/test-diagnostics-worst-case.R
@@ -27,7 +27,14 @@ test_that("a missing Rhat is counted, not silently excluded", {
   expect_length(all_missing$values, 0L)
   expect_identical(all_missing$n_missing, 2L)
 
-  expect_identical(mlumr:::.usable_diagnostic_values("not numeric")$n_total, 0L)
+  # This used to assert a total of 0, which is what let a malformed or absent
+  # column disappear from the accounting entirely. A column that is not numeric
+  # holds no usable diagnostics, and that is one missing diagnostic per
+  # parameter, not zero parameters.
+  not_numeric <- mlumr:::.usable_diagnostic_values("not numeric")
+  expect_identical(not_numeric$n_total, 1L)
+  expect_identical(not_numeric$n_missing, 1L)
+  expect_length(not_numeric$values, 0L)
 })
 
 test_that("an unknown transition count stays unknown", {
@@ -49,4 +56,64 @@ test_that("Inf is formatted as Inf rather than as a number", {
   expect_identical(mlumr:::.format_diagnostic(Inf), "Inf")
   expect_identical(mlumr:::.format_diagnostic(NaN), "NaN")
   expect_match(mlumr:::.format_diagnostic(1.0012345), "^1\\.001")
+})
+
+
+test_that("a column that is absent or not numeric is missing, not empty", {
+  # `c(NA, NA)` is LOGICAL in R, which is what a backend writes into a column
+  # it never filled. Reading that as zero diagnostics made the reporter silent
+  # about the one case it exists for.
+  d <- .usable_diagnostic_values(c(NA, NA), 2L)
+  expect_equal(d$n_missing, 2L)
+  expect_equal(d$n_total, 2L)
+  expect_length(d$values, 0L)
+
+  # An absent column, with the count the summary says it should have had.
+  d <- .usable_diagnostic_values(NULL, 5L)
+  expect_equal(d$n_missing, 5L)
+  expect_equal(d$n_total, 5L)
+
+  # A malformed column is reported, not ignored.
+  d <- .usable_diagnostic_values(c("a", "b", "c"), 3L)
+  expect_equal(d$n_missing, 3L)
+  expect_equal(d$n_total, 3L)
+
+  # A numeric column is unchanged.
+  d <- .usable_diagnostic_values(c(NA_real_, 1, 2))
+  expect_equal(d$values, c(1, 2))
+  expect_equal(d$n_missing, 1L)
+  expect_equal(d$n_total, 3L)
+})
+
+test_that("an absent column is still reported as unavailable", {
+  d <- .usable_diagnostic_values(NULL, 3L)
+  expect_message(
+    .report_missing_diagnostics(d, "Rhat", "convergence"),
+    "unavailable for 3 of 3"
+  )
+})
+
+test_that("the missing-diagnostic message names outcomes, not a cause", {
+  d <- .usable_diagnostic_values(c(1.0, NA, NA, 1.01), 4L)
+  msg <- testthat::capture_messages(
+    .report_missing_diagnostics(d, "Rhat", "convergence",
+                                c("mu_a", "mu_b", "beta[1]", "sigma"))
+  )
+  # Which parameters were not checked is something it knows.
+  expect_match(msg, "mu_b", fixed = TRUE, all = FALSE)
+  expect_match(msg, "beta[1]", fixed = TRUE, all = FALSE)
+  # Why the value is missing is not. A constant generated quantity is one
+  # reason among several and was being reported as "the usual" one.
+  expect_false(any(grepl("usual reason", msg, fixed = TRUE)))
+  expect_match(msg, "chains are stuck", fixed = TRUE, all = FALSE)
+})
+
+test_that("a fractional transition count is unknown, not zero", {
+  # as.integer() truncates, and 0 is precisely the value that says the sampler
+  # behaved, so the coercion turned an invalid count into a clean bill.
+  expect_true(is.na(.transition_count(0.5)))
+  expect_true(is.na(.transition_count(2^31)))
+  expect_equal(.transition_count(3), 3L)
+  expect_equal(.transition_count(0), 0L)
+  expect_true(is.na(.transition_count(-1)))
 })

--- a/tests/testthat/test-diagnostics-worst-case.R
+++ b/tests/testthat/test-diagnostics-worst-case.R
@@ -117,3 +117,27 @@ test_that("a fractional transition count is unknown, not zero", {
   expect_equal(.transition_count(0), 0L)
   expect_true(is.na(.transition_count(-1)))
 })
+
+test_that("a summary with no Rhat column still prints all the way through", {
+  # The unavailable line is for a fit whose column is absent, so the tables
+  # below it have to survive the same fit. Selecting "Rhat" by name raised
+  # "undefined columns selected" one line after announcing the gap.
+  df <- data.frame(
+    variable = c("mu_index", "mu_comparator", "beta[1]"),
+    mean = c(0, 1, 0.5), sd = c(1, 1, 1),
+    `2.5%` = c(-1, 0, -0.5), `97.5%` = c(1, 2, 1.5),
+    n_eff = c(500, 600, 550),
+    check.names = FALSE
+  )
+  expect_silent(cols <- mlumr:::.summary_columns(
+    df, c("variable", "mean", "sd", "2.5%", "97.5%", "Rhat")))
+  expect_false("Rhat" %in% names(cols))
+  expect_equal(names(cols), c("variable", "mean", "sd", "2.5%", "97.5%"))
+  # A summary that does carry the column is unchanged.
+  df$Rhat <- c(1.00, 1.01, 1.00)
+  expect_equal(
+    names(mlumr:::.summary_columns(
+      df, c("variable", "mean", "sd", "2.5%", "97.5%", "Rhat"))),
+    c("variable", "mean", "sd", "2.5%", "97.5%", "Rhat")
+  )
+})


### PR DESCRIPTION
Three ways the diagnostic accounting reported a fit as fine when it had not
looked.

## A missing Rhat was given a cause

The message said a constant generated quantity is "the usual reason" for an
unavailable diagnostic. Nothing had inspected the draws or identified the
variable as structurally constant; it had only seen a missing summary value.
`posterior::rhat()` documents the other reasons a value comes back `NA`,
including any chain being constant, which happens when two chains are stuck at
different constants. That is the opposite of benign.

The message now reports the outcome, names the parameters it could not check,
and leaves the cause open:

> Rhat is unavailable for 2 of 4 parameter(s), which were not checked for
> convergence; the remaining 2 were. Unavailable for: mu_b, beta[1]. A
> diagnostic that could not be computed is not one that came out well: it is
> legitimately absent for a quantity that is constant across every draw, and
> equally absent when the chains are stuck or the draws are not finite.

## An absent or non-numeric column counted as zero diagnostics

`.usable_diagnostic_values()` returned `n_missing = 0, n_total = 0` for
anything non-numeric. `c(NA, NA)` is a **logical** vector in R, which is what a
backend writes into a column it never filled, so two unavailable diagnostics
became zero diagnostics, the reporter said nothing, and the printed summary
dropped the line.

| input | before | after |
|---|---|---|
| `c(NA, NA)` | 0 of 0 | 2 missing of 2 |
| `NULL` (5 parameters expected) | 0 of 0 | 5 missing of 5 |
| `c("a","b","c")` | 0 of 0 | 3 missing of 3 |
| `c(NA, 1, 2)` | 1 of 3 | unchanged |

Callers pass the count the summary says they should have. The printed summary
no longer guards on the column being present, because that guard hid exactly
the case worth showing.

## A fractional transition count became a clean zero

`.transition_count()` validated numeric, scalar, finite and non-negative, then
applied `as.integer()`, which truncates. `0.5` became `0`, the value that says
the sampler behaved. A count past the integer range became `NA` with a
coercion warning. Both are now unknown, as an unsupplied count already was.

## Note on one test

`test-diagnostics-worst-case.R` asserted `n_total == 0` for a non-numeric
column. That is the defect written down as an expectation, so it is updated
with the reason rather than worked around.

## Not included

Whether an unexplained missing Rhat on a **core model parameter** should
warn rather than message is a policy change that alters what existing fixtures
expect. Wording and naming are here; that decision is not.

Suite: 3464 pass, 0 failed, 0 errors.