### PR TITLE
Stop drawing an interval nobody reported

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -482,7 +482,12 @@
   they mix estimators: putting `naive()`, `stc()`, and both ML-UMR models on one
   axis, for instance. It takes the reference line, axis label, title, and
   subtitle as arguments so the caller sets the measure's null rather than
-  inheriting one.
+  inheriting one. One interval far wider than the rest is clipped to a viewport
+  built from the others, with an arrow on the side it runs past, so a single
+  wide row does not squeeze the rest into a line. A bound that is infinite is
+  clipped that way; a bound that is MISSING is not, because no interval was
+  reported and drawing one from edge to edge would put an uncertainty on the
+  figure that nobody estimated. Such a row shows its point estimate alone.
 * `marginal_effects()`, `predict()`, and `conditional_effects()` now return
   lightweight `data.frame` subclasses so these `plot()` methods can dispatch;
   all existing data-frame behavior (indexing, `knitr::kable()`, the reporting

--- a/R/plot.R
+++ b/R/plot.R
@@ -1066,10 +1066,23 @@ mlumr_forest <- function(data, ref_line = NULL, log_x = FALSE,
   if (!is.null(lim)) {
     flo <- fwd(pdat$.lo)
     fhi <- fwd(pdat$.hi)
-    pdat$.clo <- !is.finite(flo) | flo < lim[1]
-    pdat$.chi <- !is.finite(fhi) | fhi > lim[2]
-    dlo_w <- ifelse(is.finite(flo), pmax(flo, lim[1]), lim[1])
-    dhi_w <- ifelse(is.finite(fhi), pmin(fhi, lim[2]), lim[2])
+    # Non-finite covered two different things. An INFINITE bound is an interval
+    # that genuinely runs past the viewport, and clipping it to the limit with
+    # an arrow is exactly right. A MISSING one means no interval was supplied
+    # or estimated, and giving it the same treatment drew a row whose CI spans
+    # the whole plot with arrows at both ends: an uncertainty nobody reported,
+    # rendered as the widest one on the figure. Missing bounds stay missing and
+    # the row is drawn as its point estimate alone.
+    have_lo <- !is.na(pdat$.lo)
+    have_hi <- !is.na(pdat$.hi)
+    pdat$.clo <- have_lo & (!is.finite(flo) | flo < lim[1])
+    pdat$.chi <- have_hi & (!is.finite(fhi) | fhi > lim[2])
+    dlo_w <- ifelse(have_lo,
+                    ifelse(is.finite(flo), pmax(flo, lim[1]), lim[1]),
+                    NA_real_)
+    dhi_w <- ifelse(have_hi,
+                    ifelse(is.finite(fhi), pmin(fhi, lim[2]), lim[2]),
+                    NA_real_)
     alen <- 0.10 * (lim[2] - lim[1])
     pdat$.dlo <- inv(dlo_w)
     pdat$.dhi <- inv(dhi_w)
@@ -1084,6 +1097,9 @@ mlumr_forest <- function(data, ref_line = NULL, log_x = FALSE,
       xintercept = ref_line, linetype = "dashed", color = "gray55"
     ) +
     ggplot2::geom_segment(
+      # A row with no interval contributes no segment, rather than one drawn
+      # from NA that ggplot2 then drops with a warning about missing values.
+      data = pdat[!is.na(pdat$.dlo) & !is.na(pdat$.dhi), , drop = FALSE],
       ggplot2::aes(x = .data$.dlo, xend = .data$.dhi,
                    y = .data$.label, yend = .data$.label),
       color = color, linewidth = 0.6

--- a/R/plot.R
+++ b/R/plot.R
@@ -1073,14 +1073,18 @@ mlumr_forest <- function(data, ref_line = NULL, log_x = FALSE,
     # the whole plot with arrows at both ends: an uncertainty nobody reported,
     # rendered as the widest one on the figure. Missing bounds stay missing and
     # the row is drawn as its point estimate alone.
-    have_lo <- !is.na(pdat$.lo)
-    have_hi <- !is.na(pdat$.hi)
-    pdat$.clo <- have_lo & (!is.finite(flo) | flo < lim[1])
-    pdat$.chi <- have_hi & (!is.finite(fhi) | fhi > lim[2])
-    dlo_w <- ifelse(have_lo,
+    # An arrow needs BOTH bounds, not just its own. With `lo = NA` and
+    # `hi = Inf` the upper flag alone was true, so the row got a lone arrow
+    # hanging off no segment, which is the same invented uncertainty in a
+    # smaller shape. A row is drawn as an interval or as a point, never as
+    # half of one.
+    have_both <- !is.na(pdat$.lo) & !is.na(pdat$.hi)
+    pdat$.clo <- have_both & (!is.finite(flo) | flo < lim[1])
+    pdat$.chi <- have_both & (!is.finite(fhi) | fhi > lim[2])
+    dlo_w <- ifelse(have_both,
                     ifelse(is.finite(flo), pmax(flo, lim[1]), lim[1]),
                     NA_real_)
-    dhi_w <- ifelse(have_hi,
+    dhi_w <- ifelse(have_both,
                     ifelse(is.finite(fhi), pmin(fhi, lim[2]), lim[2]),
                     NA_real_)
     alen <- 0.10 * (lim[2] - lim[1])

--- a/tests/testthat/test-forest-missing-interval.R
+++ b/tests/testthat/test-forest-missing-interval.R
@@ -70,3 +70,17 @@ test_that("rows without intervals do not disturb the clipping window", {
   expect_equal(with_missing$coordinates$limits$x,
                without$coordinates$limits$x)
 })
+
+test_that("a half-missing interval gets neither a segment nor a lone arrow", {
+  skip_if_not_installed("ggplot2")
+  frame <- .clipping_frame()
+  # One bound supplied and genuinely infinite, the other never reported. The
+  # upper flag alone was true, so the row was given an arrow hanging off no
+  # segment: the same invented uncertainty in a smaller shape.
+  frame$lo[frame$label == "infinite-CI"] <- NA
+  p <- mlumr_forest(frame)
+  drawn <- unlist(lapply(seq(2, length(p$layers)), function(i) .drawn(p, i)))
+  expect_false("infinite-CI" %in% drawn)
+  # The genuine outlier still gets both.
+  expect_true("outlier" %in% drawn)
+})

--- a/tests/testthat/test-forest-missing-interval.R
+++ b/tests/testthat/test-forest-missing-interval.R
@@ -1,0 +1,72 @@
+# A row with no confidence interval must not be drawn as though it had the
+# widest one on the figure.
+
+# Three ordinary rows, one genuine outlier wide enough to trigger clipping, one
+# row whose bounds were never supplied, and one whose upper bound is actually
+# infinite. Clipping has to be triggered by something else for the bug to
+# appear at all, which is what the outlier is for.
+.clipping_frame <- function() {
+  data.frame(
+    label = c("a", "b", "c", "outlier", "missing-CI", "infinite-CI"),
+    effect = "HR",
+    est = c(1.00, 1.02, 0.98, 1.00, 1.05, 1.03),
+    lo = c(0.90, 0.92, 0.88, 0.01, NA, 0),
+    hi = c(1.10, 1.12, 1.08, 1000, NA, Inf)
+  )
+}
+
+# Which rows a layer actually drew, by label.
+.drawn <- function(p, i) {
+  d <- ggplot2::layer_data(p, i)
+  if (!all(c("x", "xend", "y") %in% names(d))) {
+    return(character(0))
+  }
+  labels <- ggplot2::ggplot_build(p)$layout$panel_params[[1]]$y$get_labels()
+  labels[d$y]
+}
+
+test_that("a row with no interval is drawn as its estimate alone", {
+  skip_if_not_installed("ggplot2")
+  p <- mlumr_forest(.clipping_frame())
+
+  segments <- .drawn(p, 2)
+  expect_false("missing-CI" %in% segments)
+  # The ordinary rows and both genuinely wide ones are still drawn.
+  expect_true(all(c("a", "b", "c", "outlier", "infinite-CI") %in% segments))
+
+  # No clipping arrow on either side for the row that has no interval.
+  arrows <- unlist(lapply(seq(3, length(p$layers)), function(i) .drawn(p, i)))
+  expect_false("missing-CI" %in% arrows)
+})
+
+test_that("an infinite bound is still clipped and still gets an arrow", {
+  skip_if_not_installed("ggplot2")
+  p <- mlumr_forest(.clipping_frame())
+  arrows <- unlist(lapply(seq(3, length(p$layers)), function(i) .drawn(p, i)))
+  # Infinity genuinely runs past the viewport; that is what the arrow says.
+  expect_true("infinite-CI" %in% arrows)
+  expect_true("outlier" %in% arrows)
+})
+
+test_that("the point estimate of an interval-less row is still plotted", {
+  skip_if_not_installed("ggplot2")
+  p <- mlumr_forest(.clipping_frame())
+  # The point layer takes every row, so the estimate is not lost with the
+  # interval.
+  points <- Filter(function(i) {
+    d <- ggplot2::layer_data(p, i)
+    "x" %in% names(d) && !"xend" %in% names(d)
+  }, seq_along(p$layers))
+  expect_gt(length(points), 0)
+  d <- ggplot2::layer_data(p, points[[1]])
+  expect_equal(nrow(d), 6L)
+})
+
+test_that("rows without intervals do not disturb the clipping window", {
+  skip_if_not_installed("ggplot2")
+  frame <- .clipping_frame()
+  with_missing <- mlumr_forest(frame)
+  without <- mlumr_forest(frame[frame$label != "missing-CI", , drop = FALSE])
+  expect_equal(with_missing$coordinates$limits$x,
+               without$coordinates$limits$x)
+})


### PR DESCRIPTION
## What happens

`mlumr_forest()` clips one very wide interval so it does not squeeze the rest,
and decided a bound runs past the viewport by testing it for **non-finiteness**.
That conflates two different things:

- an **infinite** bound genuinely runs past the limit, and an arrow is right;
- a **missing** bound means no interval was supplied or estimated.

Both were replaced by the viewport limit and given a clipping arrow.

Three ordinary HR intervals, one outlier at `[0.01, 1000]` to trigger clipping,
and a fifth row with a finite estimate and both bounds `NA`:

| row | before | after |
|---|---|---|
| `a`, `b`, `c` | own bounds | unchanged |
| `outlier` | `0.868 → 1.132`, arrows both sides | unchanged |
| `missing-CI` | `0.868 → 1.132`, arrows both sides | no segment, no arrows |

The last row was drawn with the **widest uncertainty on the figure**, for the
row that had none. Clipping has to be triggered by some other row for this to
appear at all, which is why the outlier is in the fixture.

## The change

Missing bounds stay missing and the row is drawn as its point estimate alone.
The segment layer is built from the rows that have an interval, so ggplot2 is
not handed `NA` to drop with a warning about missing values. An infinite bound
is still clipped and still gets its arrow.

Also covered: the estimate is not lost along with the interval, and a row
without an interval does not move the clipping window.

## Failing first

Run against the pre-change `R/plot.R`, the two assertions about the
missing-interval row fail and the rest pass. The rest are there to catch an
over-correction that would stop drawing legitimate arrows.

Suite: 3450 pass, 0 failed, 0 errors.

## Noted, not changed

An unknown effect label still falls back to the axis for its null, which the
review flags as a separate nonblocking limitation.