### PR TITLE
Keep an interval-less point estimate inside the forest panel

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -1159,7 +1159,12 @@ mlumr_forest <- function(data, ref_line = NULL, log_x = FALSE,
   }
   keep <- ok
   keep[which(ok)[outlier]] <- FALSE
-  rng <- range(c(est[ok], lo[keep], hi[keep]), na.rm = TRUE)
+  # Every finite point estimate, not just the ones `ok` kept: a row whose
+  # interval is missing is absent from `ok`, and leaving its estimate out of
+  # the range lets coord_cartesian() clip the point itself out of the panel, so
+  # the row renders empty. Rows with an outlier interval already contribute
+  # their estimate this way; a row with no interval is the same case.
+  rng <- range(c(est[is.finite(est)], lo[keep], hi[keep]), na.rm = TRUE)
   if (!all(is.finite(rng)) || isTRUE(rng[1] == rng[2])) {
     return(NULL)
   }

--- a/tests/testthat/test-forest-missing-interval.R
+++ b/tests/testthat/test-forest-missing-interval.R
@@ -62,8 +62,13 @@ test_that("the point estimate of an interval-less row is still plotted", {
   expect_equal(nrow(d), 6L)
 })
 
-test_that("rows without intervals do not disturb the clipping window", {
+test_that("an interval-less row inside the window does not widen it", {
   skip_if_not_installed("ggplot2")
+  # Only for an estimate the window already covers. A row with no interval DOES
+  # enter the range, and has to: otherwise its point is clipped out of the panel
+  # and the row renders empty, which is the case below. This fixture's estimate
+  # is 1.05, inside the window the other rows set, so removing the row changes
+  # nothing.
   frame <- .clipping_frame()
   with_missing <- mlumr_forest(frame)
   without <- mlumr_forest(frame[frame$label != "missing-CI", , drop = FALSE])
@@ -83,4 +88,25 @@ test_that("a half-missing interval gets neither a segment nor a lone arrow", {
   expect_false("infinite-CI" %in% drawn)
   # The genuine outlier still gets both.
   expect_true("outlier" %in% drawn)
+})
+
+test_that("a point estimate outside the typical range keeps the panel", {
+  skip_if_not_installed("ggplot2")
+  # The fixture above puts its interval-less estimate at 1.05, inside the
+  # window the other rows set, so it cannot tell whether the window was built
+  # from that estimate or merely happens to contain it. Move it out to 10.
+  frame <- .clipping_frame()
+  frame$est[frame$label == "missing-CI"] <- 10
+
+  p <- mlumr_forest(frame)
+  xlim <- p$coordinates$limits$x
+  expect_false(is.null(xlim))
+  # Clipping is still on, so the window is not simply the full data range.
+  expect_lt(xlim[2], 1000)
+  # The point is drawn, and it is inside the panel rather than clipped away.
+  expect_gte(xlim[2], 10)
+
+  # The row still gets no segment and no arrow: it has no interval to show.
+  drawn <- unlist(lapply(seq(2, length(p$layers)), function(i) .drawn(p, i)))
+  expect_false("missing-CI" %in% drawn)
 })


### PR DESCRIPTION
The forest clipping window was built from rows with a complete interval only, so a row whose bounds were never reported contributed nothing to it. With clipping triggered by some other row, `coord_cartesian()` then cut the point itself out of the panel and the row rendered empty: an estimate of 10 against a window of 0.89 to 1.11 simply vanished.

The range now runs over every finite estimate. Rows with an outlier interval already contributed theirs this way, and a row with no interval is the same case. The function's own description already said it covered every point estimate.

## Why the existing test missed it

`test-forest-missing-interval.R` already asserted that an interval-less row does not disturb the clipping window, and it passes both before and after this change. Its estimate sits at 1.05, inside the window the other rows set, so it cannot distinguish a window built from that estimate from one that merely contains it. That test is renamed and commented to say what it actually establishes, and a new case moves the estimate outside.
