### PR TITLE
Record the STC separation status on the result

### DIFF
--- a/R/mlumr_class.R
+++ b/R/mlumr_class.R
@@ -422,6 +422,14 @@ print.mlumr_stc <- function(x, ...) {
       "effect-equality assumption; this calculation does not transport to ",
       "the index population.\n\n", sep = "")
 
+  # The warning at fit time has long scrolled away by the time anyone reads
+  # this, and an unverified estimate must not print like a verified one.
+  if (identical((x$separation %||% list())$status, "unknown")) {
+    cat("Separation: NOT VERIFIED (", x$separation$reason, "). Only the ",
+        "fitted-value screen ran, which cannot see quasi-complete ",
+        "separation.\n\n", sep = "")
+  }
+
   if (family == "binomial") {
     cat(sprintf("Marginalized P(Y=1|index trt, comp pop): %.4f\n", x$p_hat_index))
     cat(sprintf("Observed P(Y=1|comp trt, comp pop):      %.4f\n", x$p_comparator))

--- a/R/stc.R
+++ b/R/stc.R
@@ -69,7 +69,14 @@
 #'   range extrapolates the fitted parametric survival function and warns.
 #'   Ignored for other families.
 #'
-#' @return An object of class `mlumr_stc`
+#' @return An object of class `mlumr_stc`. Its `separation` component records
+#'   whether the outcome model's likelihood was verified to have a finite
+#'   maximum: `status` is `"not_separated"` when the exact check ran and found
+#'   none, `"unknown"` when it could not run (only the fitted-value screen was
+#'   applied, which cannot see quasi-complete separation), and
+#'   `"not_applicable"` for a family where the question does not arise. A
+#'   separated fit is refused rather than returned, so `"separated"` never
+#'   appears here.
 #' @importFrom stats gaussian poisson dnorm
 #' @export
 #'
@@ -162,6 +169,11 @@ stc <- function(data, link = NULL, conf_level = 0.95, distribution = "weibull",
     out <- .stc_survival(data, conf_level, z, distribution,
                          n_boot = as.integer(n_boot), seed = seed,
                          rmst_horizon = rmst_horizon)
+    # Survival STC fits a parametric survival model, not a binomial GLM, so the
+    # separation question does not arise. Say so rather than leave the field
+    # absent, so a caller can read it without knowing the family first.
+    out$separation <- list(status = "not_applicable",
+                           reason = "survival STC fits no binomial GLM")
     class(out) <- c("mlumr_stc", "list")
     return(out)
   }
@@ -207,6 +219,7 @@ stc <- function(data, link = NULL, conf_level = 0.95, distribution = "weibull",
                            conf_level, z, beta_hat, V, n_int)
   )
 
+  out$separation <- glm_params$separation
   class(out) <- c("mlumr_stc", "list")
   out
 }
@@ -251,8 +264,8 @@ stc <- function(data, link = NULL, conf_level = 0.95, distribution = "weibull",
       call. = FALSE
     )
   }
-  .stc_refuse_separation(fit)
-  list(beta_hat = beta_hat, V = V)
+  separation <- .stc_refuse_separation(fit)
+  list(beta_hat = beta_hat, V = V, separation = separation)
 }
 
 #' Refuse a fit whose likelihood has no finite maximum
@@ -288,17 +301,27 @@ stc <- function(data, link = NULL, conf_level = 0.95, distribution = "weibull",
 #' \pkg{detectseparation} package is installed. The threshold test stays as
 #' the part that always runs.
 #' @param fit A fitted `glm`.
-#' @return `NULL`, invisibly; called for the error.
+#' @return The separation status, invisibly: a list with `status`, one of
+#'   `"not_separated"`, `"unknown"` or `"not_applicable"`, and `reason` for
+#'   the latter two. `"separated"` is never returned, since it throws. Callers
+#'   record it on the result so a verified estimate can be told apart from an
+#'   unverified one after the warning has scrolled away.
 #' @keywords internal
 .stc_refuse_separation <- function(fit) {
   fam <- tryCatch(stats::family(fit)$family, error = function(e) NA_character_)
   if (!identical(fam, "binomial")) {
-    return(invisible(NULL))
+    return(invisible(list(
+      status = "not_applicable",
+      reason = "the outcome model is not binomial"
+    )))
   }
   mu <- stats::fitted(fit)
   mu <- mu[is.finite(mu)]
   if (!length(mu)) {
-    return(invisible(NULL))
+    return(invisible(list(
+      status = "unknown",
+      reason = "the fit has no finite fitted values to screen"
+    )))
   }
   eps <- .Machine$double.eps^0.5
   # Every fitted probability at *a* boundary, not all at the same one. A
@@ -351,7 +374,7 @@ stc <- function(data, link = NULL, conf_level = 0.95, distribution = "weibull",
       call. = FALSE
     )
   }
-  invisible(NULL)
+  invisible(exact)
 }
 
 

--- a/R/stc.R
+++ b/R/stc.R
@@ -394,8 +394,9 @@ stc <- function(data, link = NULL, conf_level = 0.95, distribution = "weibull",
 #' combination of the covariates perfectly orders the outcome, and a fit that
 #' is merely strong can look identical in the coefficients and the fitted
 #' values. \pkg{detectseparation} solves that program. It is in Suggests, so
-#' this returns `NA` when it is absent and the caller keeps the fitted-value
-#' test as its only screen; that is a weaker guarantee, not a wrong one.
+#' when it is absent this returns the `"unknown"` status with the reason, and
+#' the caller keeps the fitted-value test as its only screen; that is a weaker
+#' guarantee, not a wrong one.
 #'
 #' An error here is reported as "unknown" rather than as "separated": a refit
 #' can fail for reasons that have nothing to do with separation, and turning

--- a/R/stc.R
+++ b/R/stc.R
@@ -70,13 +70,16 @@
 #'   Ignored for other families.
 #'
 #' @return An object of class `mlumr_stc`. Its `separation` component records
-#'   whether the outcome model's likelihood was verified to have a finite
-#'   maximum: `status` is `"not_separated"` when the exact check ran and found
-#'   none, `"unknown"` when it could not run (only the fitted-value screen was
-#'   applied, which cannot see quasi-complete separation), and
-#'   `"not_applicable"` for a family where the question does not arise. A
-#'   separated fit is refused rather than returned, so `"separated"` never
-#'   appears here.
+#'   the outcome of the binomial separation check, and only that: `status` is
+#'   `"not_separated"` when the exact check ran on a binomial outcome model
+#'   and found no separation, `"unknown"` when it could not run (only the
+#'   fitted-value screen was applied, which cannot see quasi-complete
+#'   separation), and `"not_applicable"` when the outcome model is not a
+#'   binomial GLM, so this particular test has nothing to say. It is not a
+#'   certificate that the likelihood has a finite maximum for other families;
+#'   a Poisson outcome model can have an infinite maximum likelihood estimate
+#'   of its own kind, and nothing here looks for it. A separated fit is refused
+#'   rather than returned, so `"separated"` never appears here.
 #' @importFrom stats gaussian poisson dnorm
 #' @export
 #'
@@ -172,8 +175,11 @@ stc <- function(data, link = NULL, conf_level = 0.95, distribution = "weibull",
     # Survival STC fits a parametric survival model, not a binomial GLM, so the
     # separation question does not arise. Say so rather than leave the field
     # absent, so a caller can read it without knowing the family first.
-    out$separation <- list(status = "not_applicable",
-                           reason = "survival STC fits no binomial GLM")
+    out$separation <- list(
+      status = "not_applicable",
+      reason = paste("survival STC fits no binomial GLM, so the separation",
+                     "test does not apply")
+    )
     class(out) <- c("mlumr_stc", "list")
     return(out)
   }
@@ -303,16 +309,19 @@ stc <- function(data, link = NULL, conf_level = 0.95, distribution = "weibull",
 #' @param fit A fitted `glm`.
 #' @return The separation status, invisibly: a list with `status`, one of
 #'   `"not_separated"`, `"unknown"` or `"not_applicable"`, and `reason` for
-#'   the latter two. `"separated"` is never returned, since it throws. Callers
-#'   record it on the result so a verified estimate can be told apart from an
-#'   unverified one after the warning has scrolled away.
+#'   the latter two. `"separated"` is never returned, since it throws.
+#'   `"not_applicable"` means this binomial separation test does not apply to
+#'   the fitted family, not that the family has no finite-maximum problem of
+#'   its own. Callers record it on the result so a verified estimate can be
+#'   told apart from an unverified one after the warning has scrolled away.
 #' @keywords internal
 .stc_refuse_separation <- function(fit) {
   fam <- tryCatch(stats::family(fit)$family, error = function(e) NA_character_)
   if (!identical(fam, "binomial")) {
     return(invisible(list(
       status = "not_applicable",
-      reason = "the outcome model is not binomial"
+      reason = paste("the outcome model is not binomial, so the separation",
+                     "test does not apply")
     )))
   }
   mu <- stats::fitted(fit)

--- a/man/dot-stc_refuse_separation.Rd
+++ b/man/dot-stc_refuse_separation.Rd
@@ -10,7 +10,11 @@
 \item{fit}{A fitted \code{glm}.}
 }
 \value{
-\code{NULL}, invisibly; called for the error.
+The separation status, invisibly: a list with \code{status}, one of
+\code{"not_separated"}, \code{"unknown"} or \code{"not_applicable"}, and \code{reason} for
+the latter two. \code{"separated"} is never returned, since it throws. Callers
+record it on the result so a verified estimate can be told apart from an
+unverified one after the warning has scrolled away.
 }
 \description{
 The checks above look for a failure the fitting reports, and separation is

--- a/man/dot-stc_refuse_separation.Rd
+++ b/man/dot-stc_refuse_separation.Rd
@@ -12,9 +12,11 @@
 \value{
 The separation status, invisibly: a list with \code{status}, one of
 \code{"not_separated"}, \code{"unknown"} or \code{"not_applicable"}, and \code{reason} for
-the latter two. \code{"separated"} is never returned, since it throws. Callers
-record it on the result so a verified estimate can be told apart from an
-unverified one after the warning has scrolled away.
+the latter two. \code{"separated"} is never returned, since it throws.
+\code{"not_applicable"} means this binomial separation test does not apply to
+the fitted family, not that the family has no finite-maximum problem of
+its own. Callers record it on the result so a verified estimate can be
+told apart from an unverified one after the warning has scrolled away.
 }
 \description{
 The checks above look for a failure the fitting reports, and separation is

--- a/man/dot-stc_separation_status.Rd
+++ b/man/dot-stc_separation_status.Rd
@@ -21,8 +21,9 @@ question, not a threshold one: the fit is separated exactly when some linear
 combination of the covariates perfectly orders the outcome, and a fit that
 is merely strong can look identical in the coefficients and the fitted
 values. \pkg{detectseparation} solves that program. It is in Suggests, so
-this returns \code{NA} when it is absent and the caller keeps the fitted-value
-test as its only screen; that is a weaker guarantee, not a wrong one.
+when it is absent this returns the \code{"unknown"} status with the reason, and
+the caller keeps the fitted-value test as its only screen; that is a weaker
+guarantee, not a wrong one.
 }
 \details{
 An error here is reported as "unknown" rather than as "separated": a refit

--- a/man/stc.Rd
+++ b/man/stc.Rd
@@ -63,13 +63,16 @@ Ignored for other families.}
 }
 \value{
 An object of class \code{mlumr_stc}. Its \code{separation} component records
-whether the outcome model's likelihood was verified to have a finite
-maximum: \code{status} is \code{"not_separated"} when the exact check ran and found
-none, \code{"unknown"} when it could not run (only the fitted-value screen was
-applied, which cannot see quasi-complete separation), and
-\code{"not_applicable"} for a family where the question does not arise. A
-separated fit is refused rather than returned, so \code{"separated"} never
-appears here.
+the outcome of the binomial separation check, and only that: \code{status} is
+\code{"not_separated"} when the exact check ran on a binomial outcome model
+and found no separation, \code{"unknown"} when it could not run (only the
+fitted-value screen was applied, which cannot see quasi-complete
+separation), and \code{"not_applicable"} when the outcome model is not a
+binomial GLM, so this particular test has nothing to say. It is not a
+certificate that the likelihood has a finite maximum for other families;
+a Poisson outcome model can have an infinite maximum likelihood estimate
+of its own kind, and nothing here looks for it. A separated fit is refused
+rather than returned, so \code{"separated"} never appears here.
 }
 \description{
 Perform an unanchored simulated treatment comparison (STC) with marginal

--- a/man/stc.Rd
+++ b/man/stc.Rd
@@ -62,7 +62,14 @@ range extrapolates the fitted parametric survival function and warns.
 Ignored for other families.}
 }
 \value{
-An object of class \code{mlumr_stc}
+An object of class \code{mlumr_stc}. Its \code{separation} component records
+whether the outcome model's likelihood was verified to have a finite
+maximum: \code{status} is \code{"not_separated"} when the exact check ran and found
+none, \code{"unknown"} when it could not run (only the fitted-value screen was
+applied, which cannot see quasi-complete separation), and
+\code{"not_applicable"} for a family where the question does not arise. A
+separated fit is refused rather than returned, so \code{"separated"} never
+appears here.
 }
 \description{
 Perform an unanchored simulated treatment comparison (STC) with marginal

--- a/tests/testthat/test-stc-separation-and-control.R
+++ b/tests/testthat/test-stc-separation-and-control.R
@@ -496,3 +496,36 @@ test_that("an unverified estimate does not print like a verified one", {
   expect_false(any(grepl("NOT VERIFIED",
                          utils::capture.output(print(result)))))
 })
+
+test_that("an unknown status travels from the checker to the saved result", {
+  # The printing test above sets the field by hand, which checks the printing
+  # and nothing else. This forces the checker itself to come back unknown, as
+  # it does without detectseparation, and follows the status through the
+  # public call, the warning, and a round trip through disk.
+  local_mocked_bindings(
+    .stc_separation_status = function(fit) {
+      list(status = "unknown", reason = "the linear program was not run")
+    },
+    .package = "mlumr"
+  )
+  expect_warning(result <- stc(.stc_binomial_fixture()),
+                 "exact separation check did not run")
+  expect_identical(result$separation$status, "unknown")
+  expect_identical(result$separation$reason, "the linear program was not run")
+
+  path <- withr::local_tempfile(fileext = ".rds")
+  saveRDS(result, path)
+  back <- readRDS(path)
+  expect_identical(back$separation, result$separation)
+  expect_output(print(back), "Separation: NOT VERIFIED")
+  expect_output(print(back), "the linear program was not run")
+})
+
+test_that("not_applicable names the test that does not apply, not a verdict", {
+  set.seed(2026)
+  d <- data.frame(y = stats::rpois(50, 2), x = stats::rnorm(50))
+  fit <- stats::glm(y ~ x, family = stats::poisson(), data = d)
+  got <- mlumr:::.stc_refuse_separation(fit)
+  expect_identical(got$status, "not_applicable")
+  expect_match(got$reason, "separation test does not apply")
+})

--- a/tests/testthat/test-stc-separation-and-control.R
+++ b/tests/testthat/test-stc-separation-and-control.R
@@ -435,3 +435,64 @@ test_that("a sampler setting is validated the same through either door", {
   expect_equal(ok$control$adapt_delta, 0.99)
   expect_equal(ok$control$max_treedepth, 10)
 })
+
+# The check runs, warns and is then thrown away, so nothing downstream can tell
+# a verified estimate from an unverified one once the warning has scrolled off.
+
+.stc_binomial_fixture <- function() {
+  set.seed(2026)
+  n <- 200
+  x1 <- stats::rbinom(n, 1, 0.4)
+  x2 <- stats::rbinom(n, 1, 0.6)
+  outcome <- stats::rbinom(n, 1, stats::plogis(-0.5 + x1 - 0.5 * x2))
+  ipd <- set_ipd(data.frame(trt = "A", outcome = outcome, x1 = x1, x2 = x2),
+                 "trt", "outcome", c("x1", "x2"))
+  agd <- set_agd(data.frame(trt = "B", n_total = 300, n_events = 120,
+                            x1_mean = 0.3, x2_mean = 0.7),
+                 "trt", outcome_n = "n_total", outcome_r = "n_events",
+                 cov_means = c("x1_mean", "x2_mean"))
+  dat <- combine_data(ipd, agd)
+  add_integration(dat, n_int = 32,
+                  x1 = distr(qbern, prob = x1_mean),
+                  x2 = distr(qbern, prob = x2_mean))
+}
+
+test_that("the separation check reports its outcome instead of discarding it", {
+  set.seed(2026)
+  n <- 200
+  x <- stats::rnorm(n)
+  ordinary <- data.frame(y = stats::rbinom(n, 1, stats::plogis(0.3 * x)), x = x)
+  fit_ok <- stats::glm(y ~ x, family = stats::binomial(), data = ordinary)
+
+  got <- mlumr:::.stc_refuse_separation(fit_ok)
+  expect_type(got, "list")
+  expect_true(got$status %in% c("not_separated", "unknown"))
+  # Only "separated" is withheld, because it throws rather than returns.
+  expect_false(identical(got$status, "separated"))
+})
+
+test_that("a family with no separation question says so rather than nothing", {
+  set.seed(2026)
+  d <- data.frame(y = stats::rnorm(50), x = stats::rnorm(50))
+  fit <- stats::glm(y ~ x, family = stats::gaussian(), data = d)
+  expect_identical(mlumr:::.stc_refuse_separation(fit)$status, "not_applicable")
+})
+
+test_that("an stc result records the separation status it was given", {
+  result <- suppressWarnings(stc(.stc_binomial_fixture()))
+  expect_false(is.null(result$separation))
+  expect_true(result$separation$status %in% c("not_separated", "unknown"))
+})
+
+test_that("an unverified estimate does not print like a verified one", {
+  result <- suppressWarnings(stc(.stc_binomial_fixture()))
+
+  result$separation <- list(status = "unknown",
+                            reason = "the optional package is not installed")
+  expect_output(print(result), "Separation: NOT VERIFIED")
+  expect_output(print(result), "the optional package is not installed")
+
+  result$separation <- list(status = "not_separated")
+  expect_false(any(grepl("NOT VERIFIED",
+                         utils::capture.output(print(result)))))
+})

--- a/tests/testthat/test-stc-separation-and-control.R
+++ b/tests/testthat/test-stc-separation-and-control.R
@@ -35,6 +35,9 @@ test_that("an ordinary fit and a genuinely rare event are still accepted", {
 
   ordinary <- data.frame(y = stats::rbinom(n, 1, stats::plogis(0.3 * x)), x = x)
   fit_ok <- stats::glm(y ~ x, family = stats::binomial(), data = ordinary)
+  # Silence needs the exact check to have run; without detectseparation the
+  # same fit warns that it did not, which is its own test below.
+  skip_if_not_installed("detectseparation")
   expect_silent(mlumr:::.stc_refuse_separation(fit_ok))
 
   # A small rate is not separation. The test is on the boundary rather than on


### PR DESCRIPTION
`stc()` runs the exact separation check, warns when it could not run, and then discards the outcome. By the time anyone reads the estimate the warning has scrolled away, and nothing on the object distinguishes a binomial fit the exact check cleared from one where only the fitted-value screen ran, which cannot see quasi-complete separation at all.

The status is now carried onto the result as `separation`, with `status` and a `reason`, and `print()` shows an explicit NOT VERIFIED line when the exact check did not run.

The estimate is still returned, exactly as before. This adds the record, not a refusal, which keeps it consistent with the earlier decision to warn and return rather than gate.

## Scope of the field

It records the outcome of the **binomial separation check** and nothing else. `"not_applicable"` means that test does not apply to the fitted family, including survival, and is recorded rather than leaving the field absent so a caller can read it without first knowing the family. It is not a certificate that the likelihood has a finite maximum for other families; a Poisson outcome model can have an infinite maximum likelihood estimate of its own kind, and nothing here looks for it. `"separated"` never appears, because that case throws.

The route is tested end to end: the checker is forced to come back unknown, and the status is followed through the public call, its warning, and a round trip through `saveRDS()` to the printed NOT VERIFIED line.
