### PR TITLE
Refuse a missing survival shape instead of substituting 1

### DIFF
--- a/R/predict.R
+++ b/R/predict.R
@@ -1434,13 +1434,83 @@ marginal_effects <- function(object,
        " baseline.", call. = FALSE)
 }
 
-#' Auxiliary (shape) draws for one treatment, defaulting to 1 when absent
+#' Auxiliary (shape) draws for one treatment
+#'
+#' Layouts in order, in the same spirit as [.surv_scoef_draws()]:
+#'   `aux_val` / `aux_val_cmp`   the named per-treatment views
+#'   `aux_raw[1,s]`              the underlying parameter matrix
+#' The second exists because the views are TRANSFORMED parameters, so a fit made
+#' with `pars = c("aux_val", "aux_val_cmp"), include = FALSE` drops them and
+#' keeps the raw matrix they are read off. Both are consulted for the treatment
+#' asked about before anything else is: the comparator falls back to the index
+#' view only when there is a single stratum, where Stan makes them the same
+#' number. Under `aux_by = ".study"` they are different studies' shapes.
+#'
+#' A shape of 1 is returned only where Stan itself fixes it at 1: a
+#' distribution that has no such shape, where the raw matrix has no rows at all.
+#' That is `dist` 1 and 4 for the first shape and every `dist` but 9 for the
+#' second. Substituting 1 for a shape that merely could not be found gives a
+#' different distribution without saying so: at `dist` 2 it turns a Weibull into
+#' an exponential.
+#'
+#' @param object A fitted `mlumr_fit`.
+#' @param base `"aux_val"` or `"aux2_val"`.
+#' @param treatment `"index"` or `"comparator"`.
+#' @param n Number of draws, for the fixed-at-one case.
+#' @return Numeric vector of `n` draws.
 #' @keywords internal
 .surv_aux_draws <- function(object, base, treatment, n) {
   draws <- object$draws
   cmp <- paste0(base, "_cmp")
-  nm <- if (identical(treatment, "comparator") && cmp %in% names(draws)) cmp else base
-  if (nm %in% names(draws)) draws[[nm]] else rep(1, n)
+  raw <- sub("_val$", "_raw", base)
+  n_strata <- object$stan_data$n_strata %||% 1L
+  comparator <- identical(treatment, "comparator")
+
+  # This treatment's own layouts, view before raw matrix. The comparator's
+  # stratum is the last one, which is stratum 1 when the baseline is shared.
+  own <- if (comparator) {
+    c(cmp, paste0(raw, "[1,", n_strata, "]"))
+  } else {
+    c(base, paste0(raw, "[1,1]"))
+  }
+  for (nm in own) {
+    if (nm %in% names(draws)) {
+      return(draws[[nm]])
+    }
+  }
+
+  # With one stratum Stan reads both views off the same `aux_raw[1,1]`, so
+  # either serves for either treatment and a fit that saved only one of them is
+  # still readable. With more than one they are different studies' shapes, and
+  # crossing over would hand a treatment the other study's baseline without
+  # saying so: the substitution this function exists to stop.
+  if (n_strata == 1L) {
+    for (nm in c(base, cmp, paste0(raw, "[1,1]"))) {
+      if (nm %in% names(draws)) {
+        return(draws[[nm]])
+      }
+    }
+  }
+
+  # Positive membership on both branches, never a negation. `!identical(dist,
+  # 9L)` was true for a dist_code arriving as the double 9, and for an absent or
+  # NA one, so a generalized gamma could still be handed a second shape of 1:
+  # the substitution this function exists to stop, in the one branch that had
+  # been left permitting it. An unrecognized code now takes the error path.
+  dist <- object$surv_info$dist_code
+  fixed_at_one <- if (identical(base, "aux2_val")) {
+    isTRUE(dist %in% 1L:8L)
+  } else {
+    isTRUE(dist %in% c(1L, 4L))
+  }
+  if (fixed_at_one) {
+    return(rep(1, n))
+  }
+  stop("Could not find ", base, " draws for the ", treatment, " baseline. ",
+       "The ", object$surv_info$distribution %||% "fitted",
+       " distribution has this shape, so it cannot be defaulted to 1. ",
+       "Refit without excluding `", base, "`, `", cmp, "` or `", raw,
+       "` from the saved parameters.", call. = FALSE)
 }
 
 

--- a/man/dot-surv_aux_draws.Rd
+++ b/man/dot-surv_aux_draws.Rd
@@ -2,11 +2,39 @@
 % Please edit documentation in R/predict.R
 \name{.surv_aux_draws}
 \alias{.surv_aux_draws}
-\title{Auxiliary (shape) draws for one treatment, defaulting to 1 when absent}
+\title{Auxiliary (shape) draws for one treatment}
 \usage{
 .surv_aux_draws(object, base, treatment, n)
 }
+\arguments{
+\item{object}{A fitted \code{mlumr_fit}.}
+
+\item{base}{\code{"aux_val"} or \code{"aux2_val"}.}
+
+\item{treatment}{\code{"index"} or \code{"comparator"}.}
+
+\item{n}{Number of draws, for the fixed-at-one case.}
+}
+\value{
+Numeric vector of \code{n} draws.
+}
 \description{
-Auxiliary (shape) draws for one treatment, defaulting to 1 when absent
+Layouts in order, in the same spirit as \code{\link[=.surv_scoef_draws]{.surv_scoef_draws()}}:
+\code{aux_val} / \code{aux_val_cmp}   the named per-treatment views
+\code{aux_raw[1,s]}              the underlying parameter matrix
+The second exists because the views are TRANSFORMED parameters, so a fit made
+with \verb{pars = c("aux_val", "aux_val_cmp"), include = FALSE} drops them and
+keeps the raw matrix they are read off. Both are consulted for the treatment
+asked about before anything else is: the comparator falls back to the index
+view only when there is a single stratum, where Stan makes them the same
+number. Under \code{aux_by = ".study"} they are different studies' shapes.
+}
+\details{
+A shape of 1 is returned only where Stan itself fixes it at 1: a
+distribution that has no such shape, where the raw matrix has no rows at all.
+That is \code{dist} 1 and 4 for the first shape and every \code{dist} but 9 for the
+second. Substituting 1 for a shape that merely could not be found gives a
+different distribution without saying so: at \code{dist} 2 it turns a Weibull into
+an exponential.
 }
 \keyword{internal}

--- a/tests/testthat/test-survival-aux-by.R
+++ b/tests/testthat/test-survival-aux-by.R
@@ -151,7 +151,7 @@ test_that("the R readers find the baseline under every draw-name layout", {
                mlumr:::.surv_scoef_draws(legacy, "comparator"))
 })
 
-test_that("the shape draws fall back to the index stratum and then to 1", {
+test_that("the shape draws read their own stratum, then fall back", {
   mk <- function(nms) {
     d <- as.data.frame(matrix(1.5, nrow = 2, ncol = max(length(nms), 1)))
     if (length(nms)) names(d) <- nms
@@ -162,10 +162,25 @@ test_that("the shape draws fall back to the index stratum and then to 1", {
                c(1.5, 1.5))
   expect_equal(unname(mlumr:::.surv_aux_draws(both, "aux_val", "comparator", 2)),
                c(2.5, 2.5))
-  # exponential has no shape at all: default to 1, never error
-  none <- structure(list(draws = data.frame(mu_index = c(0, 0))),
-                    class = "mlumr_fit")
+  # exponential has no shape at all: default to 1, never error. The fit has to
+  # SAY it is an exponential for that to hold. This stub previously carried no
+  # `surv_info` at all, so what it actually asserted was that any fit missing
+  # its shape draws gets 1, which is the case a shape of 1 must not cover: at
+  # dist 2 it turns the fitted Weibull into an exponential and reports every
+  # number that follows without a word.
+  none <- structure(
+    list(draws = data.frame(mu_index = c(0, 0)),
+         surv_info = list(dist_code = 1L, distribution = "exponential")),
+    class = "mlumr_fit")
   expect_equal(mlumr:::.surv_aux_draws(none, "aux_val", "index", 2), c(1, 1))
+
+  # The complement, which the old stub could not express.
+  weib <- structure(
+    list(draws = data.frame(mu_index = c(0, 0)),
+         surv_info = list(dist_code = 2L, distribution = "weibull")),
+    class = "mlumr_fit")
+  expect_error(mlumr:::.surv_aux_draws(weib, "aux_val", "index", 2),
+               "Could not find aux_val draws")
 })
 
 test_that("a stratified conditional hazard ratio warns instead of misreporting", {

--- a/tests/testthat/test-survival-aux-draws.R
+++ b/tests/testthat/test-survival-aux-draws.R
@@ -1,0 +1,120 @@
+# A shape parameter that could not be found is not a shape parameter of 1.
+# Substituting one silently turns the fitted distribution into a different one:
+# at dist 2 a Weibull becomes an exponential, and every survival, hazard and
+# RMST prediction downstream is computed from the wrong model.
+
+.aux_fit <- function(draws, dist = 2L, n_strata = 2L,
+                     distribution = "weibull") {
+  list(draws = draws,
+       stan_data = list(n_strata = n_strata),
+       surv_info = list(dist_code = dist, distribution = distribution))
+}
+
+test_that("the named per-treatment views are used when present", {
+  fit <- .aux_fit(list(aux_val = c(1.1, 1.2), aux_val_cmp = c(2.1, 2.2)))
+  expect_equal(mlumr:::.surv_aux_draws(fit, "aux_val", "index", 2),
+               c(1.1, 1.2))
+  expect_equal(mlumr:::.surv_aux_draws(fit, "aux_val", "comparator", 2),
+               c(2.1, 2.2))
+})
+
+test_that("the raw parameter matrix is read when the views were excluded", {
+  # `aux_val` is a TRANSFORMED parameter, so pars/include = FALSE drops it and
+  # leaves the matrix it is read off. Stratum 1 is the index, stratum n_strata
+  # the comparator.
+  draws <- list(`aux_raw[1,1]` = c(1.1, 1.2), `aux_raw[1,2]` = c(2.1, 2.2))
+  fit <- .aux_fit(draws)
+  expect_equal(mlumr:::.surv_aux_draws(fit, "aux_val", "index", 2),
+               c(1.1, 1.2))
+  expect_equal(mlumr:::.surv_aux_draws(fit, "aux_val", "comparator", 2),
+               c(2.1, 2.2))
+})
+
+test_that("a shared baseline reads the same stratum for both treatments", {
+  fit <- .aux_fit(list(`aux_raw[1,1]` = c(1.5, 1.6)), n_strata = 1L)
+  expect_equal(mlumr:::.surv_aux_draws(fit, "aux_val", "comparator", 2),
+               c(1.5, 1.6))
+})
+
+test_that("an unfindable shape is refused rather than defaulted to 1", {
+  fit <- .aux_fit(list(eta = c(0, 0)))
+  expect_error(mlumr:::.surv_aux_draws(fit, "aux_val", "index", 2),
+               "Could not find aux_val draws")
+  expect_error(mlumr:::.surv_aux_draws(fit, "aux_val", "index", 2), "weibull")
+  # gengamma's second shape is a real parameter too.
+  gg <- .aux_fit(list(eta = c(0, 0)), dist = 9L, distribution = "gengamma")
+  expect_error(mlumr:::.surv_aux_draws(gg, "aux2_val", "index", 2),
+               "Could not find aux2_val draws")
+})
+
+test_that("1 is still returned where Stan itself fixes the shape at 1", {
+  # dist 1 and 4 have no shape: Stan declares aux_raw with zero rows and sets
+  # the transformed value to 1.0, so there is nothing to find and 1 is right.
+  for (d in c(1L, 4L)) {
+    fit <- .aux_fit(list(eta = c(0, 0)), dist = d)
+    expect_equal(mlumr:::.surv_aux_draws(fit, "aux_val", "index", 2), c(1, 1))
+  }
+  # Only gengamma has a second shape, so every other distribution fixes it.
+  fit <- .aux_fit(list(eta = c(0, 0)), dist = 8L, distribution = "gamma")
+  expect_equal(mlumr:::.surv_aux_draws(fit, "aux2_val", "index", 3), c(1, 1, 1))
+})
+
+test_that("the comparator reads its own stratum before any index fallback", {
+  # `aux_val_cmp` excluded, `aux_val` kept. Taking the index view here would
+  # give the comparator the index study's shape under `aux_by = ".study"`,
+  # which is the substitution this function exists to stop, one axis over.
+  draws <- list(aux_val = c(1.1, 1.2), `aux_raw[1,2]` = c(2.1, 2.2))
+  fit <- .aux_fit(draws)
+  expect_equal(mlumr:::.surv_aux_draws(fit, "aux_val", "comparator", 2),
+               c(2.1, 2.2))
+})
+
+test_that("a stratified fit with only the index view is refused", {
+  fit <- .aux_fit(list(aux_val = c(1.1, 1.2)))
+  expect_error(mlumr:::.surv_aux_draws(fit, "aux_val", "comparator", 2),
+               "Could not find aux_val draws")
+})
+
+test_that("a shared baseline still lets the comparator read the index view", {
+  # One stratum: Stan sets aux_val_cmp from the same aux_raw[1,1], so the two
+  # are the same number and a fit that saved only one of them is readable.
+  fit <- .aux_fit(list(aux_val = c(1.5, 1.6)), n_strata = 1L)
+  expect_equal(mlumr:::.surv_aux_draws(fit, "aux_val", "comparator", 2),
+               c(1.5, 1.6))
+})
+
+test_that("an unrecognized distribution code takes the error path", {
+  # The second-shape branch used to be written as a negation, so anything that
+  # was not the integer 9 counted as "no second shape". A gengamma whose code
+  # arrives as the double 9 is still a gengamma, and an absent or NA code is not
+  # a licence to substitute 1.
+  gg <- .aux_fit(list(eta = c(0, 0)), dist = 9, distribution = "gengamma")
+  expect_error(mlumr:::.surv_aux_draws(gg, "aux2_val", "index", 2),
+               "Could not find aux2_val draws")
+
+  for (bad in list(NA_integer_, NULL)) {
+    fit <- .aux_fit(list(eta = c(0, 0)), dist = bad, distribution = "unknown")
+    expect_error(mlumr:::.surv_aux_draws(fit, "aux2_val", "index", 2),
+                 "Could not find aux2_val draws")
+    expect_error(mlumr:::.surv_aux_draws(fit, "aux_val", "index", 2),
+                 "Could not find aux_val draws")
+  }
+
+  # A recognized code given as a double is still recognized.
+  gam <- .aux_fit(list(eta = c(0, 0)), dist = 8, distribution = "gamma")
+  expect_equal(mlumr:::.surv_aux_draws(gam, "aux2_val", "index", 2), c(1, 1))
+})
+
+test_that("a shared baseline is symmetric between the two views", {
+  # One stratum, and only the comparator view survives. Stan reads both views
+  # off the same aux_raw[1,1] there, so the index can use it; refusing would
+  # fail predict() for a shape that is present under another name.
+  fit <- .aux_fit(list(aux_val_cmp = c(1.5, 1.6)), n_strata = 1L)
+  expect_equal(mlumr:::.surv_aux_draws(fit, "aux_val", "index", 2), c(1.5, 1.6))
+
+  # With two strata the two views are different studies' shapes, so the index
+  # must not borrow the comparator's.
+  strat <- .aux_fit(list(aux_val_cmp = c(1.5, 1.6)), n_strata = 2L)
+  expect_error(mlumr:::.surv_aux_draws(strat, "aux_val", "index", 2),
+               "Could not find aux_val draws")
+})


### PR DESCRIPTION
`predict()` and `conditional_effects()` read the fitted shape parameter by name and fell back to 1 whenever the name was absent.

A shape of 1 is not a neutral default. At `dist` 2 it turns the fitted Weibull into an exponential, and every survival, hazard and RMST number computed from it is then a number from a different model, reported without a word.

## Recover, then refuse

`aux_val` and `aux_val_cmp` are transformed parameters, so a fit made with `pars`/`include = FALSE` drops them while keeping `aux_raw`, the matrix they are read off.

Each treatment now reads **its own** layouts first, view then raw matrix entry: stratum 1 for the index, stratum `n_strata` for the comparator, which is what Stan does. Crossing over is allowed only when `n_strata == 1`, where Stan reads both views off the same `aux_raw[1,1]` and they are the same number; there it is symmetric, so a fit that saved either one is readable. With more than one stratum they are different studies' shapes, and borrowing would hand a treatment the other study's baseline without saying so.

1 is returned only where Stan itself fixes the shape at 1: `dist` 1 and 4 for the first shape, every `dist` but 9 for the second, where the raw matrix has no rows to find. Both branches test positive membership rather than a negation, so a code arriving as a double, or absent, or `NA`, takes the error path instead of quietly selecting a shape of 1.

This mirrors `.surv_scoef_draws()` directly above, which already tries the layouts in order and stops when none of them is there.

## An existing test asserted the old behavior

`test-survival-aux-by.R` had a case commented "exponential has no shape at all: default to 1, never error", but its stub carried no `surv_info`, so what it actually asserted was that any fit missing its shape draws gets 1. The stub now declares the exponential it claims to be, and the complementary Weibull case it could not previously express is added.
