### PR TITLE
Say what the correlation_pairs counts measure

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -236,7 +236,7 @@
   some pair with a correlation to realize could not be measured, and
   `"review"` whenever a measured pair misses the heuristic, whatever else
   is missing. A new `correlation_pairs` component counts the pairs
-  expected and measured, against the target and between resolutions, and
+  expected and measured, on the doubled grid and between resolutions, and
   names the omitted ones with a reason; a margin declared with no variance
   has no correlation to realize, so its pairs are listed separately and
   kept out of the count, while a rare variable the grid never varied is a

--- a/R/integration.R
+++ b/R/integration.R
@@ -612,11 +612,15 @@ unnest_integration <- function(data) {
 #'   correlation to realize could not be measured, since a maximum over the
 #'   measured pairs says nothing about the rest; a measured pair that misses
 #'   the heuristic is `"review"` regardless. `correlation_pairs` counts the
-#'   pairs expected and measured, against the target (the doubled grid) and
-#'   between resolutions (both grids), names the omitted ones with a reason,
-#'   and lists separately the pairs in which a margin is declared with no
-#'   variance, which have no correlation to realize and are outside the
-#'   count.
+#'   pairs expected and the pairs measured: `measured` is the number with a
+#'   finite correlation on the doubled grid, the correlation the target
+#'   comparison uses when there is a target to compare it with, and
+#'   `measured_resolution` the number with a finite correlation on both
+#'   grids. Neither count says whether a target comparison was made; with
+#'   `cor_adjust = "none"` none is. It names the omitted pairs with a
+#'   reason, and lists separately the pairs in which a margin is declared
+#'   with no variance, which have no correlation to realize and are outside
+#'   the count.
 #'
 #'   For a binary margin the declared-target SD is the distribution's,
 #'   `sqrt(p * (1 - p))` from the declared mean, whatever `_sd` column the
@@ -851,7 +855,7 @@ check_integration <- function(data, ..., cor = NULL, cor_adjust = NULL,
         cat("Target correlation: not available (no finite comparison).\n")
       }
       if (nrow(pairs$omitted)) {
-        cat(sprintf(paste0("Pairs compared: %d of %d against the target, %d ",
+        cat(sprintf(paste0("Pairs measured: %d of %d on the doubled grid, %d ",
                            "of %d between resolutions. Not measured: %s. ",
                            "A maximum above is over the measured pairs ",
                            "only.\n"),

--- a/man/check_integration.Rd
+++ b/man/check_integration.Rd
@@ -49,11 +49,15 @@ are \code{"partial"} when the measured pairs pass but some pair with a
 correlation to realize could not be measured, since a maximum over the
 measured pairs says nothing about the rest; a measured pair that misses
 the heuristic is \code{"review"} regardless. \code{correlation_pairs} counts the
-pairs expected and measured, against the target (the doubled grid) and
-between resolutions (both grids), names the omitted ones with a reason,
-and lists separately the pairs in which a margin is declared with no
-variance, which have no correlation to realize and are outside the
-count.
+pairs expected and the pairs measured: \code{measured} is the number with a
+finite correlation on the doubled grid, the correlation the target
+comparison uses when there is a target to compare it with, and
+\code{measured_resolution} the number with a finite correlation on both
+grids. Neither count says whether a target comparison was made; with
+\code{cor_adjust = "none"} none is. It names the omitted pairs with a
+reason, and lists separately the pairs in which a margin is declared
+with no variance, which have no correlation to realize and are outside
+the count.
 
 For a binary margin the declared-target SD is the distribution's,
 \code{sqrt(p * (1 - p))} from the declared mean, whatever \verb{_sd} column the

--- a/tests/testthat/test-integration-check-targets.R
+++ b/tests/testthat/test-integration-check-targets.R
@@ -145,7 +145,7 @@ test_that("check_integration() reports a partial correlation verdict", {
   expect_identical(unique(ck$correlation_pairs$omitted$reason),
                    "constant_on_grid")
   out <- capture.output(run(make(), verbose = TRUE))
-  expect_true(any(grepl("Pairs compared: 1 of 3", out)))
+  expect_true(any(grepl("Pairs measured: 1 of 3", out)))
   expect_true(any(grepl("a~rare", out)))
   # A measured pair that misses the heuristic is `review`, whatever else is
   # missing: a requested a~b correlation of 0.9 between margins of 0.1 and


### PR DESCRIPTION
Follow-up to #62, answering the open review thread there.

`correlation_pairs$measured` is the number of pairs with a finite correlation on the doubled grid, and `measured_resolution` the number finite on both grids. Neither count says whether a target comparison was made; with `cor_adjust = "none"` there is no target to compare with, yet the verbose message said "Pairs compared: ... against the target". The message now says "Pairs measured: ... on the doubled grid", the help describes both counts by the grid they come from and states that no target comparison exists in that mode, and the NEWS entry matches. The one test that pinned the message text is updated.

Full pure-R suite: 65 files, 4170 pass, 0 fail, 0 error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified how integration checks report expected and measured correlation pairs across doubled grids and resolutions.
  - Documented omitted pairs, zero-variance margins, and cases where target comparisons are not performed.
  - Updated diagnostic wording to refer to “Pairs measured” for clearer output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->