### PR TITLE
Keep each target profile's share of the binomial STC gradient

### DIFF
--- a/R/link_functions.R
+++ b/R/link_functions.R
@@ -201,13 +201,23 @@ inverse_link <- function(x, link = c("identity", "log", "logit", "probit", "clog
   x <- x[keep]
   weights <- weights[keep]
   log_weights <- log(weights)
-  z <- x + log_weights
+  # Shift by the largest `x` before the weights are added, not after. A log
+  # probability can be enormous: the complementary log-log non-event one is
+  # -exp(eta), which is -3.2e16 at eta = 38, where the double's spacing is
+  # 4. Adding log(w) there rounds it to a multiple of 4, and the weights
+  # come back out of `exp(z - m)` as powers of e^4 that no data supplied.
+  # The shift is exact for values that close together, and what remains is
+  # of order one, where a weight is visible again. The mean of identical
+  # values is then exactly that value, however they are weighted, which is
+  # what makes the shares in [.stc_binomial_gradients()] normalize.
+  m_x <- max(x)
+  if (is.infinite(m_x)) return(m_x)
+  z <- (x - m_x) + log_weights
   m_num <- max(z)
-  if (is.infinite(m_num)) return(m_num)
   m_den <- max(log_weights)
   log_num <- m_num + log(sum(exp(z - m_num)))
   log_den <- m_den + log(sum(exp(log_weights - m_den)))
-  log_num - log_den
+  m_x + (log_num - log_den)
 }
 
 

--- a/R/stc.R
+++ b/R/stc.R
@@ -782,8 +782,17 @@ stc <- function(data, link = NULL, conf_level = 0.95, distribution = "weibull",
   log_w <- log(weights) - log(sum(weights))
   log_p_mean <- .weighted_log_mean_exp(lp$event, weights)
   log_q_mean <- .weighted_log_mean_exp(lp$nonevent, weights)
-  share_p <- exp(log_w + lp$event - log_p_mean)
-  share_q <- exp(log_w + lp$nonevent - log_q_mean)
+  # Subtract the mean first, then add the weight. The other order adds a
+  # weight of order 1 to a log probability of order 1e17 (the cloglog
+  # non-event log probability is -exp(eta), which is -2.4e17 at eta = 40),
+  # where the double's spacing is 32 and the weight is lost entirely. Every
+  # point then takes the whole share instead of its own: a target that is 64
+  # copies of one profile gave a link gradient of 64 where standardizing a
+  # point mass cannot change its link at all, so the answer is 1. Centering
+  # first cancels the huge common term against itself, exactly, and leaves
+  # the weight against a number of order 1.
+  share_p <- exp(log_w + (lp$event - log_p_mean))
+  share_q <- exp(log_w + (lp$nonevent - log_q_mean))
   grad_log_p <- colSums(share_p * d_log_p * X)
   grad_log_q <- if (link == "cloglog") {
     # The non-event derivative -exp(eta) overflows past eta = 709, where the
@@ -794,7 +803,7 @@ stc <- function(data, link = NULL, conf_level = 0.95, distribution = "weibull",
     # `.binary_link_from_logs()` reports is +Inf, and the gradient is NaN
     # with it; the finite-variance guard then refuses the fit, as it did
     # before, rather than attach a finite SE to an infinite estimate.
-    colSums(-exp(log_w + lp$nonevent - log_q_mean + eta) * X)
+    colSums(-exp(log_w + (lp$nonevent - log_q_mean) + eta) * X)
   } else {
     colSums(share_q * d_log_q * X)
   }
@@ -809,7 +818,15 @@ stc <- function(data, link = NULL, conf_level = 0.95, distribution = "weibull",
     } else {
       -exp(log_q_mean - log_phi_z) * grad_log_q
     }
-  } else if (log_p_mean < -18) {
+  } else if (log_q_mean == 0) {
+    # `d log q-bar / log q-bar` is the link's own derivative and is exact
+    # wherever it can be formed. The non-event log probability is built as
+    # -exp(eta) rather than as log(1 - p), so it stays representable until
+    # exp(eta) itself underflows below eta = -745; only there is the link
+    # log(-log q-bar) equal to log p-bar to double precision. Switching at
+    # log p-bar = -18 instead left the point-mass derivative at 1 - p-bar / 2
+    # rather than 1, a relative 1e-9 at eta = -20 where the exact form was
+    # available.
     grad_log_p
   } else {
     grad_log_q / log_q_mean

--- a/R/stc.R
+++ b/R/stc.R
@@ -788,17 +788,36 @@ stc <- function(data, link = NULL, conf_level = 0.95, distribution = "weibull",
   log_w <- log_weights - (m_w + log(sum(exp(log_weights - m_w))))
   log_p_mean <- .weighted_log_mean_exp(lp$event, weights)
   log_q_mean <- .weighted_log_mean_exp(lp$nonevent, weights)
-  # Subtract the mean first, then add the weight. The other order adds a
-  # weight of order 1 to a log probability of order 1e17 (the cloglog
-  # non-event log probability is -exp(eta), which is -2.4e17 at eta = 40),
-  # where the double's spacing is 32 and the weight is lost entirely. Every
-  # point then takes the whole share instead of its own: a target that is 64
-  # copies of one profile gave a link gradient of 64 where standardizing a
-  # point mass cannot change its link at all, so the answer is 1. Centering
-  # first cancels the huge common term against itself, exactly, and leaves
-  # the weight against a number of order 1.
-  share_p <- exp(log_w + (lp$event - log_p_mean))
-  share_q <- exp(log_w + (lp$nonevent - log_q_mean))
+  # The share `w_i p_i / sum(w p)`, normalized in the frame where the common
+  # term has already cancelled, and never against the scalar mean.
+  #
+  # Two orders fail here and they fail differently. Adding the weight before
+  # the mean is subtracted puts a weight of order 1 beside a log probability
+  # of order 1e17 (cloglog's non-event one is -exp(eta), -2.4e17 at eta 40),
+  # where the double's spacing is 32 and the weight is lost outright: 64
+  # copies of one profile gave a link gradient of 64, where standardizing a
+  # point mass cannot change its link and the answer is 1.
+  #
+  # Subtracting the mean first fixes that case and not the general one,
+  # because `log_p_mean` is itself the largest log probability plus a
+  # correction of order 1, and that sum is where the spacing swallows the
+  # correction. The reconstruction then hands the dominant point its own
+  # weight instead of the whole share: two equally weighted cloglog points
+  # at eta 40 and 40 + 1e-14 gave a link gradient of 0.5, and so did every
+  # other spacing, up to eta 40 beside eta 50 where the second point is not
+  # there at all. Cancelling the maximum before the shares are formed never
+  # writes the correction next to it, and the shares sum to 1 by
+  # construction rather than by cancellation.
+  log_shares <- function(x) {
+    m_x <- max(x)
+    z <- (x - m_x) + log_w
+    m_z <- max(z)
+    z - (m_z + log(sum(exp(z - m_z))))
+  }
+  log_share_p <- log_shares(lp$event)
+  log_share_q <- log_shares(lp$nonevent)
+  share_p <- exp(log_share_p)
+  share_q <- exp(log_share_q)
   grad_log_p <- colSums(share_p * d_log_p * X)
   grad_log_q <- if (link == "cloglog") {
     # The non-event derivative -exp(eta) overflows past eta = 709, where the
@@ -809,7 +828,7 @@ stc <- function(data, link = NULL, conf_level = 0.95, distribution = "weibull",
     # `.binary_link_from_logs()` reports is +Inf, and the gradient is NaN
     # with it; the finite-variance guard then refuses the fit, as it did
     # before, rather than attach a finite SE to an infinite estimate.
-    colSums(-exp(log_w + (lp$nonevent - log_q_mean) + eta) * X)
+    colSums(-exp(log_share_q + eta) * X)
   } else {
     colSums(share_q * d_log_q * X)
   }

--- a/R/stc.R
+++ b/R/stc.R
@@ -779,7 +779,13 @@ stc <- function(data, link = NULL, conf_level = 0.95, distribution = "weibull",
     d_log_p <- exp(eta - exp(eta) - lp$event)
     d_log_q <- NULL
   }
-  log_w <- log(weights) - log(sum(weights))
+  # The log weights are normalized by a shifted log-sum-exp, not by
+  # log(sum(weights)): two weights of 1e308 are finite and their sum is not,
+  # which sent every log share to -Inf and the gradient of a point mass to 0.
+  # [.weighted_log_mean_exp()] normalizes its denominator the same way.
+  log_weights <- log(weights)
+  m_w <- max(log_weights)
+  log_w <- log_weights - (m_w + log(sum(exp(log_weights - m_w))))
   log_p_mean <- .weighted_log_mean_exp(lp$event, weights)
   log_q_mean <- .weighted_log_mean_exp(lp$nonevent, weights)
   # Subtract the mean first, then add the weight. The other order adds a

--- a/tests/testthat/test-stc-binomial-gradients.R
+++ b/tests/testthat/test-stc-binomial-gradients.R
@@ -225,24 +225,76 @@ test_that("weights on identical profiles are a resolution, not an answer", {
   }
 })
 
+test_that("a dominant tail point carries the whole share, not its own weight", {
+  # `log_p_mean` is itself the largest log probability plus a correction of
+  # order one, and that sum is where the spacing swallows the correction:
+  # cloglog's non-event log probability is -exp(eta), -2.4e17 at eta = 40,
+  # where a double's neighbors are 32 apart. A share rebuilt as
+  # `log_w + (lp - log_p_mean)` therefore hands the dominant point its own
+  # weight where the whole share belongs to it, and the shares stop summing
+  # to one. Standardizing to a target that one point dominates cannot change
+  # that point's link, so the answer is 1 at every spacing: this returned
+  # 0.5 for two equally weighted points at every spacing below, including
+  # eta = 40 beside eta = 50, where the second point is not there at all.
+  X <- matrix(1, nrow = 2L, ncol = 1L)
+  for (d in c(1e-14, 1e-12, 1e-10, 1, 10)) {
+    for (w in list(c(0.5, 0.5), c(0.25, 0.75), c(1, 3))) {
+      lab <- paste("spacing", d, "weights", paste(w, collapse = "/"))
+      g <- mlumr:::.stc_binomial_gradients(X, c(40, 40 + d), w, "cloglog")
+      expect_equal(unname(g$link), 1, tolerance = 1e-9, label = lab)
+      # The mirror, with the dominant point second. Which point dominates
+      # the non-event mean is the SMALLER eta, since q = exp(-exp(eta)).
+      h <- mlumr:::.stc_binomial_gradients(X, c(40 + d, 40), w, "cloglog")
+      expect_equal(unname(h$link), 1, tolerance = 1e-9,
+                   label = paste(lab, "reversed"))
+    }
+  }
+  # Not vacuous: where no point dominates the answer is not 1, and these two
+  # agree with a central difference of the standardized link to 1e-10.
+  expect_equal(
+    unname(mlumr:::.stc_binomial_gradients(X, c(0, 0.5), c(0.5, 0.5),
+                                           "cloglog")$link),
+    0.96074225539, tolerance = 1e-9
+  )
+  expect_equal(
+    unname(mlumr:::.stc_binomial_gradients(X, c(-1, 2), c(0.5, 0.5),
+                                           "cloglog")$link),
+    0.35291962139, tolerance = 1e-9
+  )
+})
+
 test_that("the normalized shares of the two means each sum to one", {
   # The share c_i = w_i p_i / sum(w p) is what the gradient weights each
   # point's derivative by, so the identity sum(c_i) = 1 is the statement
   # that no point's contribution was lost or counted twice. Taking the
   # gradient with X a column of ones reads the sum back directly, since
   # each point's derivative of log p in an intercept is d log p / d eta.
-  set.seed(2026)
-  w <- runif(50, 0.01, 10)
-  eta <- c(rnorm(46), 35, 38, 40, -40)
-  X <- matrix(1, nrow = 50L, ncol = 1L)
-  for (link in c("logit", "probit", "cloglog")) {
-    lp <- mlumr:::.binary_log_probs(eta, link)
-    log_p_mean <- mlumr:::.weighted_log_mean_exp(lp$event, w)
-    log_q_mean <- mlumr:::.weighted_log_mean_exp(lp$nonevent, w)
+  #
+  # The shares are formed the way the code forms them, by cancelling the
+  # maximum first, not by subtracting the scalar mean: the second set of
+  # etas below is one where those two differ, and the scalar-mean form gives
+  # 0.5 there rather than 1.
+  shares <- function(x, w) {
     log_w <- log(w) - log(sum(w))
-    expect_equal(sum(exp(log_w + (lp$event - log_p_mean))), 1,
-                 tolerance = 1e-12, label = paste(link, "event"))
-    expect_equal(sum(exp(log_w + (lp$nonevent - log_q_mean))), 1,
-                 tolerance = 1e-12, label = paste(link, "non-event"))
+    m_x <- max(x)
+    z <- (x - m_x) + log_w
+    m_z <- max(z)
+    exp(z - (m_z + log(sum(exp(z - m_z)))))
+  }
+  set.seed(2026)
+  cases <- list(
+    list(w = runif(50, 0.01, 10), eta = c(rnorm(46), 35, 38, 40, -40)),
+    list(w = c(0.5, 0.5), eta = c(40, 40 + 1e-14)),
+    list(w = c(0.25, 0.75), eta = c(40, 50))
+  )
+  for (cs in cases) {
+    for (link in c("logit", "probit", "cloglog")) {
+      lp <- mlumr:::.binary_log_probs(cs$eta, link)
+      lab <- paste(link, length(cs$eta), "points")
+      expect_equal(sum(shares(lp$event, cs$w)), 1,
+                   tolerance = 1e-12, label = paste(lab, "event"))
+      expect_equal(sum(shares(lp$nonevent, cs$w)), 1,
+                   tolerance = 1e-12, label = paste(lab, "non-event"))
+    }
   }
 })

--- a/tests/testthat/test-stc-binomial-gradients.R
+++ b/tests/testthat/test-stc-binomial-gradients.R
@@ -173,3 +173,67 @@ test_that("the gradients stay finite in tails the probabilities cannot represent
   g_inf <- mlumr:::.stc_binomial_gradients(X, c(800, 800), c(1, 1), "cloglog")
   expect_false(all(is.finite(g_inf$link)))
 })
+
+test_that("replicating one target profile does not change the link gradient", {
+  # A target made of copies of a single profile is the same point mass
+  # however many copies it holds, and standardizing a point mass returns
+  # the point: g(g^-1(eta)) = eta, whose derivative in an intercept is 1.
+  # The count and the weights are the resolution of a grid, not a property
+  # of the target, so neither may appear in the answer. Before, the cloglog
+  # non-event share lost its weight to rounding against a log probability of
+  # -exp(eta) and every copy took the whole share: 16, 64 and 128 at
+  # eta = 40, and 0.293 at eta = 38 where the loss is partial.
+  for (link in c("logit", "probit", "cloglog")) {
+    for (eta in c(-40, -20, 0, 20, 35, 38, 40)) {
+      for (n in c(1L, 16L, 64L, 128L)) {
+        g <- mlumr:::.stc_binomial_gradients(
+          matrix(1, nrow = n, ncol = 1L), rep(eta, n), rep(1, n), link
+        )
+        expect_equal(unname(g$link), 1, tolerance = 1e-9,
+                     label = paste(link, "eta", eta, "n", n))
+      }
+    }
+  }
+})
+
+test_that("weights on identical profiles are a resolution, not an answer", {
+  # Unequal weights on copies of one profile still describe that point mass,
+  # and scaling every weight by a constant leaves the normalized shares
+  # alone. Both must leave the link gradient at 1.
+  set.seed(2026)
+  w <- runif(64, 0.01, 10)
+  for (link in c("logit", "probit", "cloglog")) {
+    for (eta in c(-38, 0, 38, 40)) {
+      X <- matrix(1, nrow = 64L, ncol = 1L)
+      g <- mlumr:::.stc_binomial_gradients(X, rep(eta, 64L), w, link)
+      expect_equal(unname(g$link), 1, tolerance = 1e-9,
+                   label = paste(link, eta))
+      scaled <- mlumr:::.stc_binomial_gradients(X, rep(eta, 64L), 1e6 * w,
+                                                link)
+      expect_equal(scaled$link, g$link, tolerance = 1e-12)
+      expect_equal(scaled$log_mean, g$log_mean, tolerance = 1e-12)
+    }
+  }
+})
+
+test_that("the normalized shares of the two means each sum to one", {
+  # The share c_i = w_i p_i / sum(w p) is what the gradient weights each
+  # point's derivative by, so the identity sum(c_i) = 1 is the statement
+  # that no point's contribution was lost or counted twice. Taking the
+  # gradient with X a column of ones reads the sum back directly, since
+  # each point's derivative of log p in an intercept is d log p / d eta.
+  set.seed(2026)
+  w <- runif(50, 0.01, 10)
+  eta <- c(rnorm(46), 35, 38, 40, -40)
+  X <- matrix(1, nrow = 50L, ncol = 1L)
+  for (link in c("logit", "probit", "cloglog")) {
+    lp <- mlumr:::.binary_log_probs(eta, link)
+    log_p_mean <- mlumr:::.weighted_log_mean_exp(lp$event, w)
+    log_q_mean <- mlumr:::.weighted_log_mean_exp(lp$nonevent, w)
+    log_w <- log(w) - log(sum(w))
+    expect_equal(sum(exp(log_w + (lp$event - log_p_mean))), 1,
+                 tolerance = 1e-12, label = paste(link, "event"))
+    expect_equal(sum(exp(log_w + (lp$nonevent - log_q_mean))), 1,
+                 tolerance = 1e-12, label = paste(link, "non-event"))
+  }
+})

--- a/tests/testthat/test-stc-binomial-gradients.R
+++ b/tests/testthat/test-stc-binomial-gradients.R
@@ -212,6 +212,15 @@ test_that("weights on identical profiles are a resolution, not an answer", {
                                                 link)
       expect_equal(scaled$link, g$link, tolerance = 1e-12)
       expect_equal(scaled$log_mean, g$log_mean, tolerance = 1e-12)
+      # Weights whose sum is not representable. Each is finite and their
+      # ratios are what a share is made of, so the answer is the same 1;
+      # dividing by log(sum(weights)) made every log share -Inf and the
+      # gradient 0.
+      huge <- mlumr:::.stc_binomial_gradients(
+        matrix(1, nrow = 2L, ncol = 1L), rep(eta, 2L), c(1e308, 1e308), link
+      )
+      expect_equal(unname(huge$link), 1, tolerance = 1e-9,
+                   label = paste(link, eta, "weights summing past the range"))
     }
   }
 })


### PR DESCRIPTION
## What was wrong

A target made of many copies of one covariate profile is the same point mass
however many copies it holds, so standardizing it returns the point and the
link-scale derivative in an intercept is exactly 1. Under the complementary
log-log link it was not:

| eta | copies | link gradient | correct |
|---:|---:|---:|---:|
| 35 | 64 | 0.913 | 1 |
| 38 | 16 | 0.293 | 1 |
| 38 | 128 | 2.344 | 1 |
| 40 | 64 | 64 | 1 |

For a one-coordinate covariance this multiplies the standard error by the
number of grid points and the variance by its square.

## Why

The complementary log-log non-event log probability is `-exp(eta)`, which is
`-2.4e17` at eta 40. A double's neighbors are 32 apart there, so adding a log
weight of order 1 to it changes nothing: every point's normalized share came
back as 1 instead of 1/n and the grid resolution entered the answer. At
eta 38 the loss is partial and the factor is whatever the rounding left.

Two sites added the weight before subtracting the common term. Both now
subtract first, which is exact for values that close together, and add the
weight to a number of order 1.

* `.weighted_log_mean_exp()` shifts by the largest value before the weights
  are added rather than after, so the mean of identical values is exactly
  that value however they are weighted.
* `.stc_binomial_gradients()` forms each share as
  `exp(log_w + (log_p - log_p_mean))`.

While here, the complementary log-log link gradient switched to its
small-probability form at `log p-bar < -18`, where the exact form
`d log q-bar / log q-bar` is still available: the non-event log probability
is built as `-exp(eta)`, not as `log(1 - p)`, so it stays representable until
`exp(eta)` itself underflows below eta -745. The switch is now on that, which
is what the documentation already described, and the point-mass derivative at
eta -20 is 1 rather than `1 - p-bar / 2`.

## Tests

`test-stc-binomial-gradients.R` gains three cases: the replicated point mass
for all three links across eta in {-40, -20, 0, 20, 35, 38, 40} and 1 to 128
copies; unequal weights on identical profiles and a rescaling of all weights;
and that both sets of normalized shares sum to one. The known answer is 1,
not merely a finite number, which is what the existing tail tests checked.

Full suite: 4315 passing, 0 failures, 0 errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numerical stability for weighted calculations involving extremely large or small values.
  * Fixed binomial gradient calculations to preserve very small contributions and maintain accurate results with extreme predictors.
  * Improved handling of complementary log-log link gradients in edge cases.

* **Tests**
  * Added regression coverage across logit, probit, and complementary log-log links, including varied weights, profile replication, and extreme predictor values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->