### PR TITLE
Identify a correlation pair by its members, not by its printed label

### DIFF
--- a/R/integration.R
+++ b/R/integration.R
@@ -599,8 +599,9 @@ unnest_integration <- function(data) {
 #' @return A list with components `marginals` (the original data frame
 #'   returned by previous versions) and, if `check_joint = TRUE`,
 #'   `correlations`, a data frame of pairwise covariate correlations at
-#'   the current and doubled `n_int` for each AgD row. Printed with a
-#'   pass/warn verdict.
+#'   the current and doubled `n_int` for each AgD row. Its `covariate_1`
+#'   and `covariate_2` columns name the two margins; `pair` is a label
+#'   built from them for reading. Printed with a pass/warn verdict.
 #'
 #'   The `verdict` component reports `"stable"` / `"close"` when a comparison
 #'   was made and met the heuristic, `"review"` when it did not, and
@@ -935,6 +936,13 @@ check_integration <- function(data, ..., cor = NULL, cor_adjust = NULL,
       rho_t <- if (!is.null(cor_target)) cor_target[i, j] else NA_real_
       rows[[idx]] <- data.frame(
         agd_row = k,
+        # The two members are carried as their own fields. `pair` is a label
+        # built from them for reading, and a label is not an encoding: a
+        # covariate may be named `a~b`, which `set_ipd()` and `set_agd()`
+        # both accept, and splitting `a~b~c` on the tilde gives `a`, `b` and
+        # `c`, none of which is either member.
+        covariate_1 = cov_names[i],
+        covariate_2 = cov_names[j],
         pair = sprintf("%s~%s", cov_names[i], cov_names[j]),
         cor_method = cor_method,
         cor_current = round(rho_o, 4),
@@ -953,7 +961,11 @@ check_integration <- function(data, ..., cor = NULL, cor_adjust = NULL,
 
 #' Which correlation pairs were measured, and why the others were not
 #'
-#' @param diff The pair table from [.int_cor_stats()].
+#' @param diff The pair table from [.int_cor_stats()]. Its members are read
+#'   from the `covariate_1` and `covariate_2` columns, never from the `pair`
+#'   label, which is presentation and does not identify them: a covariate
+#'   named `a~b` makes the label `a~b~c`, and a name that is a substring of
+#'   another would match the wrong margin besides.
 #' @param stats The marginal statistics of the current grid.
 #' @param target_sd Declared target SDs, one per row of `stats`.
 #' @return List with `expected`, the number of pairs that have a correlation
@@ -974,7 +986,7 @@ check_integration <- function(data, ..., cor = NULL, cor_adjust = NULL,
 #' @keywords internal
 .int_cor_pair_status <- function(diff, stats, target_sd) {
   degenerate <- vapply(seq_len(nrow(diff)), function(i) {
-    members <- strsplit(diff$pair[i], "~", fixed = TRUE)[[1L]]
+    members <- c(diff$covariate_1[i], diff$covariate_2[i])
     rows <- stats$covariate %in% members & stats$agd_row == diff$agd_row[i]
     any(is.finite(target_sd[rows]) & target_sd[rows] == 0)
   }, logical(1))

--- a/man/check_integration.Rd
+++ b/man/check_integration.Rd
@@ -36,8 +36,9 @@ dependence structure does not (rare in practice for QMC with sensible
 A list with components \code{marginals} (the original data frame
 returned by previous versions) and, if \code{check_joint = TRUE},
 \code{correlations}, a data frame of pairwise covariate correlations at
-the current and doubled \code{n_int} for each AgD row. Printed with a
-pass/warn verdict.
+the current and doubled \code{n_int} for each AgD row. Its \code{covariate_1}
+and \code{covariate_2} columns name the two margins; \code{pair} is a label
+built from them for reading. Printed with a pass/warn verdict.
 
 The \code{verdict} component reports \code{"stable"} / \code{"close"} when a comparison
 was made and met the heuristic, \code{"review"} when it did not, and

--- a/man/dot-int_cor_pair_status.Rd
+++ b/man/dot-int_cor_pair_status.Rd
@@ -7,7 +7,11 @@
 .int_cor_pair_status(diff, stats, target_sd)
 }
 \arguments{
-\item{diff}{The pair table from \code{\link[=.int_cor_stats]{.int_cor_stats()}}.}
+\item{diff}{The pair table from \code{\link[=.int_cor_stats]{.int_cor_stats()}}. Its members are read
+from the \code{covariate_1} and \code{covariate_2} columns, never from the \code{pair}
+label, which is presentation and does not identify them: a covariate
+named \code{a~b} makes the label \code{a~b~c}, and a name that is a substring of
+another would match the wrong margin besides.}
 
 \item{stats}{The marginal statistics of the current grid.}
 

--- a/tests/testthat/test-integration-check-targets.R
+++ b/tests/testthat/test-integration-check-targets.R
@@ -212,3 +212,79 @@ test_that("a margin declared without variance leaves the other pairs an ordinary
   expect_identical(ck1$verdict$target_correlation, "unavailable")
   expect_identical(ck1$verdict$resolution_correlation, "unavailable")
 })
+
+test_that("a tilde in a covariate name cannot hide a failed correlation", {
+  # `pair` is a label for reading. Recovering the two margins by splitting it
+  # on the tilde is not the inverse of building it: `set_ipd()` and
+  # `set_agd()` both accept `a~b` as a covariate name, so the pair of `a~b`
+  # and `c` is labeled `a~b~c`, which splits into `a`, `b` and `c`. The
+  # unrelated `a` is declared with no variance, and finding it excluded the
+  # one pair with a correlation to realize: a declared target of 0.9 between
+  # margins of 0.1 and 0.9, whose Frechet bound is 0.11, came back as
+  # `expected` 0 and `unavailable` instead of `review`.
+  set.seed(2026)
+  nm <- c("a~b", "c", "a")
+  src <- data.frame(trt = "A", y = rbinom(40, 1, 0.5),
+                    `a~b` = rbinom(40, 1, 0.1), c = rbinom(40, 1, 0.9),
+                    a = rbinom(40, 1, 0.5), check.names = FALSE)
+  ip <- set_ipd(src, "trt", outcome = "y", covariates = nm)
+  ad <- data.frame(trt = "B", n = 60L, r = 20L, `a~b_mean` = 0.1,
+                   c_mean = 0.9, a_mean = 0, check.names = FALSE)
+  ag <- set_agd(ad, "trt", outcome_n = "n", outcome_r = "r",
+                cov_means = c("a~b_mean", "c_mean", "a_mean"),
+                cov_sds = rep(NA_character_, 3L),
+                cov_types = rep("binary", 3L))
+  cor <- diag(3)
+  dimnames(cor) <- list(nm, nm)
+  cor["a~b", "c"] <- cor["c", "a~b"] <- 0.9
+  specs <- list(`a~b` = distr(qbern, prob = `a~b_mean`),
+                c = distr(qbern, prob = c_mean),
+                a = distr(qbern, prob = a_mean))
+  base <- list(combine_data(ip, ag), n_int = 256, cor = cor,
+               cor_adjust = "pearson", verbose = FALSE)
+  d <- suppressWarnings(do.call(add_integration, c(base, specs)))
+  recheck <- list(d, cor = cor, cor_adjust = "pearson", verbose = FALSE)
+  ck <- suppressWarnings(do.call(check_integration, c(recheck, specs)))
+  expect_identical(ck$correlations$covariate_1, c("a~b", "a~b", "c"))
+  expect_identical(ck$correlations$covariate_2, c("c", "a", "a"))
+  expect_identical(ck$correlation_pairs$expected, 1L)
+  expect_identical(ck$correlation_pairs$measured, 1L)
+  expect_identical(ck$verdict$target_correlation, "review")
+  expect_gt(max(ck$correlations$abs_diff_target, na.rm = TRUE), 0.5)
+})
+
+test_that("renaming the covariates does not change which pairs are judged", {
+  # The applicability of a pair is a property of the declared margins, so a
+  # one-to-one renaming must leave the counts, the omissions and the pair
+  # the maxima are taken over exactly where they were. Names carrying the
+  # pair separator, names that are substrings of other names and names that
+  # are not syntactic R identifiers are all legal.
+  X <- cbind(rep(c(-1, -1, 1, 1), 16), rep(c(-1, 1, -1, 1), 16),
+             rep(c(-1, 1), 32), rep(0, 64))
+  target_sd <- c(1, 1, 1, 0)
+  status <- function(nms) {
+    colnames(X) <- nms
+    orig <- array(X, dim = c(1L, nrow(X), ncol(X)),
+                  dimnames = list(NULL, NULL, nms))
+    dbl <- array(rbind(X, X), dim = c(1L, 2L * nrow(X), ncol(X)),
+                 dimnames = list(NULL, NULL, nms))
+    tab <- mlumr:::.int_cor_stats(orig, dbl, nms, 1L, cor_target = diag(4),
+                                  cor_method = "pearson")$diff
+    st <- mlumr:::.int_cor_pair_status(
+      tab, mlumr:::.int_stats(orig, nms, 1L), target_sd
+    )
+    st$pair <- NULL
+    list(expected = st$expected, measured = st$measured,
+         measured_resolution = st$measured_resolution,
+         applicable = st$applicable, n_omitted = nrow(st$omitted),
+         n_not_applicable = nrow(st$not_applicable),
+         max_target = max(tab$abs_diff_target[st$applicable]))
+  }
+  plain <- status(c("w", "x", "y", "z"))
+  expect_identical(plain$expected, 3L)
+  for (nms in list(c("a~b", "c", "d", "a"),
+                   c("age", "age_group", "sex", "sex_male"),
+                   c("x 1", "x.1", "x-1", "x~1"))) {
+    expect_identical(status(nms), plain, label = paste(nms, collapse = ", "))
+  }
+})


### PR DESCRIPTION
## What was wrong

`.int_cor_stats()` labels the pair of covariates `a` and `b` as `a~b`, and
`.int_cor_pair_status()` recovered the two names with
`strsplit(pair, "~", fixed = TRUE)`. That is not the inverse of building the
label. A covariate may be named `a~b`: `set_ipd()` and `set_agd()` both
accept it. Its pair with `c` is labeled `a~b~c`, which splits into `a`, `b`
and `c`, none of which is either member.

Any of those fragments can name a different covariate. If that one is
declared with no variance, the pair it has nothing to do with is marked
inapplicable, leaves the `expected` count, and drops out of the maximum the
target verdict is taken over.

## The public path, before and after

Three binary covariates `a~b`, `c` and `a`; a declared target correlation of
0.9 between margins of 0.1 and 0.9, whose Frechet bound is 0.11; `a`
declared all-zero and so genuinely degenerate.

| | before | after |
|---|---:|---:|
| `correlation_pairs$expected` | 0 | 1 |
| `correlation_pairs$measured` | 0 | 1 |
| `verdict$target_correlation` | `unavailable` | `review` |

The realized correlation on the grid is 0.11 against the declared 0.9, a
miss of 0.787, and the checker said nothing had been measured.

## The fix

`.int_cor_stats()` carries `covariate_1` and `covariate_2` as their own
fields and builds `pair` from them for reading;
`.int_cor_pair_status()` reads the fields. The two columns are in the
`correlations` table `check_integration()` returns, so a caller has the
identities as data rather than as text to parse.

## Tests

* The public path on the fixture above. It reports `expected` 0 and
  `unavailable` against the previous source.
* A one-to-one renaming of the covariates leaves `expected`, `measured`,
  `measured_resolution`, the omitted set, the not-applicable set and the
  logical the maxima are taken over identical. Covered: names carrying the
  separator, names that are substrings of other names, and names that are
  not syntactic R identifiers.

Full suite: 4199 passing, 0 failures, 0 errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved integration correlation diagnostics for covariate names containing tildes, overlapping text, or non-standard identifiers.
  * Pair-status results now consistently report applicable pairs, omissions, resolution counts, maximum differences, and review outcomes.
  * Added explicit covariate fields to make compared margins clear alongside the display label.

* **Documentation**
  * Updated integration diagnostic documentation to describe the new covariate fields and pair-label limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->