### PR TITLE
Say what the contrast coverage, the aggregate constraint and the Poisson supremum actually are

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -196,14 +196,18 @@
   `poisson.test()` report, whose coverage is at least the nominal level for
   every true value; a comparator built from several aggregate rows is
   pooled, which is conservative for the size-weighted mean of its strata.
-  The arm standard errors are unchanged and still feed the contrasts, whose
-  intervals remain Wald on the link scale around the boundary-corrected
-  quantities: enumerating every pair of counts at 100 per arm, they cover
-  the true log odds ratio, log risk ratio and risk difference between 0.939
-  and 0.9999 of the time over true probabilities from 0.014 to 0.986, which
-  the documentation now states. The standardized index probability of an
-  STC is a model prediction and keeps its delta-method interval, documented
-  as an asymptotic approximation.
+  The arm standard errors are unchanged and still feed the contrasts, which
+  are not exact and are not claimed to be: the link-scale contrast and the
+  log risk ratio remain Wald around the boundary-corrected quantities and
+  the risk difference remains Wald on the natural scale around the raw
+  difference of proportions. Twelve configurations at 100 observations per
+  arm are pinned in the tests by enumerating every pair of counts, and the
+  documentation now reports those twelve as the values at those true
+  probabilities rather than as a range: they run from 0.853 to 0.9999, and
+  coverage is worst near opposite boundaries, where a true risk difference
+  of 0.966 is covered 85.3% of the time. The standardized index probability
+  of an STC is a model prediction and keeps its delta-method interval,
+  documented as an asymptotic approximation.
 
 * **Binomial STC uncertainty no longer depends on the units of a covariate.**
   The delta-method gradients of the standardized event probability, its
@@ -245,9 +249,11 @@
 * **A Poisson STC with no finite maximum likelihood estimate is refused.**
   The Poisson log-likelihood is `sum(y * eta - E * exp(eta))` up to a
   constant, so along a direction of the coefficients that leaves every
-  positive-count row's rate fixed and lowers a zero-count row's it rises
-  without bound: with no events at all, or with a subgroup that has none
-  while another has some. Iterative reweighting stops anyway when the
+  positive-count row's rate fixed and lowers a zero-count row's it
+  increases toward a supremum it never attains: with no events at all, or
+  with a subgroup that has none while another has some. The likelihood
+  itself is bounded, by 1 when there are no events; what is missing is a
+  finite coefficient that maximizes it. Iterative reweighting stops anyway when the
   deviance stops changing, and reported convergence, finite coefficients
   and a finite covariance from where it stopped: 80 zero counts gave an
   intercept near -27 with a standard error near 57,500, and a zero-event

--- a/NEWS.md
+++ b/NEWS.md
@@ -203,9 +203,11 @@
   difference of proportions. Twelve configurations at 100 observations per
   arm are pinned in the tests by enumerating every pair of counts, and the
   documentation now reports those twelve as the values at those true
-  probabilities rather than as a range: they run from 0.853 to 0.9999, and
-  coverage is worst near opposite boundaries, where a true risk difference
-  of 0.966 is covered 85.3% of the time. The standardized index probability
+  probabilities rather than as a range: they run from 0.853 to 0.9999. The
+  risk difference is worst between opposite boundaries, where a true
+  difference of 0.966 is covered 85.3% of the time, and the log risk ratio
+  is worst with both arms near the same boundary, where 0.986 against 0.957
+  is covered 92.1%. The standardized index probability
   of an STC is a model prediction and keeps its delta-method interval,
   documented as an asymptotic approximation.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -251,7 +251,7 @@
 * **A Poisson STC with no finite maximum likelihood estimate is refused.**
   The Poisson log-likelihood is `sum(y * eta - E * exp(eta))` up to a
   constant, so along a direction of the coefficients that leaves every
-  positive-count row's rate fixed and lowers a zero-count row's it
+  positive-count row's rate fixed and lowers a zero-count row's rate, it
   increases toward a supremum it never attains: with no events at all, or
   with a subgroup that has none while another has some. The likelihood
   itself is bounded, by 1 when there are no events; what is missing is a

--- a/R/mlumr.R
+++ b/R/mlumr.R
@@ -928,10 +928,19 @@
 #' the constrained combination. With a nonlinear link the constrained
 #' quantity is the marginalized outcome mean, probability or rate, which is
 #' a function of the whole assumed covariate distribution and not of its
-#' mean profile alone: a normal outcome under `link = "log"` gives the
-#' aggregate mean `exp(mu + beta m + beta^2 v / 2)`, so two rows with the
-#' same mean `m` and different variances `v` constrain different things and
-#' their Jacobian in `(mu, beta)` has full rank. Local rank there is not
+#' mean profile alone: a normal outcome under `link = "log"`, with the
+#' covariate normally distributed within the row, gives the aggregate mean
+#' `g = exp(mu + beta m + beta^2 v / 2)`, so two rows with the same mean `m`
+#' and different variances `v` can constrain different things. Both
+#' qualifications are load-bearing. That expression is the covariate's
+#' moment generating function, so it is the covariate distribution that has
+#' to be normal, not the outcome family alone; a distribution with the same
+#' first two moments and a different shape gives a different aggregate mean.
+#' And the Jacobian of the two rows in `(mu, beta)` has determinant
+#' `g_1 g_2 beta (v_2 - v_1)`, so it is full rank only where the variances
+#' differ AND the slope is away from zero. At `beta = 0` the two rows
+#' constrain the same quantity however far apart their variances are, and
+#' the rank drops to one. Local rank there is not
 #' global identification and neither is precision; the three have to be
 #' assessed separately. For one covariate with an
 #' identity link, independent normal priors of variance `a^2` on the

--- a/R/mlumr.R
+++ b/R/mlumr.R
@@ -697,12 +697,6 @@
 #' to the whole, the estimand does not change with how the aggregate evidence
 #' happens to be tabulated.
 #'
-#' **Weakly-identified coefficients in the relaxed model**:
-#' `beta_comparator` is identified only through AgD, so the relaxed
-#' model needs informative priors (or many AgD rows) to estimate
-#' effect modification reliably. [prior_sensitivity()] is the
-#' recommended diagnostic.
-#'
 #' @seealso [prior_sensitivity()] for sensitivity of the posterior
 #'   to `prior_beta`; [set_agd()] for AgD scale requirements;
 #'   [prior_summary()] for introspection of the priors actually used.
@@ -925,12 +919,21 @@
 #' intercept (the primary relaxed-SPFA strategy of Chandler & Ishak,
 #' Section 2.2.1). A single aggregate outcome summary generally cannot
 #' separately identify all comparator coefficients and the comparator
-#' intercept. Its likelihood term constrains one combination of them, the
-#' comparator intercept plus the coefficients weighted by that row's
-#' covariate means on the model's scale, which under `center = TRUE` are the
-#' declared means minus the pooled center; the directions the row does not
-#' constrain remain prior-driven, although their marginal posteriors can
-#' still move through the constrained combination. For one covariate with an
+#' intercept. What its likelihood term constrains depends on the link. With
+#' an identity link it is one linear combination of them, the comparator
+#' intercept plus the coefficients weighted by that row's covariate means on
+#' the model's scale, which under `center = TRUE` are the declared means
+#' minus the pooled center; the directions the row does not constrain remain
+#' prior-driven, although their marginal posteriors can still move through
+#' the constrained combination. With a nonlinear link the constrained
+#' quantity is the marginalized outcome mean, probability or rate, which is
+#' a function of the whole assumed covariate distribution and not of its
+#' mean profile alone: a normal outcome under `link = "log"` gives the
+#' aggregate mean `exp(mu + beta m + beta^2 v / 2)`, so two rows with the
+#' same mean `m` and different variances `v` constrain different things and
+#' their Jacobian in `(mu, beta)` has full rank. Local rank there is not
+#' global identification and neither is precision; the three have to be
+#' assessed separately. For one covariate with an
 #' identity link, independent normal priors of variance `a^2` on the
 #' intercept and `b^2` on the coefficient, a centered mean `m` and an outcome
 #' SE `s`, the posterior variance of the coefficient is
@@ -938,11 +941,11 @@
 #' row whose mean sits at the pooled center, and smaller the further the
 #' row's mean sits from it. Joint, nonoverlapping subgroup summaries each add
 #' a likelihood term; how many directions those terms identify depends on
-#' their number, their covariate-distribution geometry (rows with the same
-#' mean profile tighten one combination and add no direction), the outcome
-#' precision and the model, and for a nonlinear link differences in the
-#' distributions beyond the mean profiles matter too. Remaining directions
-#' require explicit prior sensitivity analysis. (Marginal, overlapping
+#' their number, their covariate-distribution geometry (under an identity
+#' link, rows with the same mean profile tighten one combination and add no
+#' direction; under a nonlinear link they can differ in spread or dependence
+#' and constrain different combinations), the outcome precision and the
+#' model. Remaining directions require explicit prior sensitivity analysis. (Marginal, overlapping
 #' subgroups would double-count patients and understate uncertainty; supply
 #' jointly-defined subgroups.)
 #'

--- a/R/naive.R
+++ b/R/naive.R
@@ -31,12 +31,14 @@
 #' 95%. Their recorded coverage runs from 0.853 to 0.9999. Those are the
 #' values at those true probabilities and they bound nothing else: the
 #' twelve do not cover other probabilities, other sample sizes, other links,
-#' stratified AgD or a transported [stc()] contrast. Coverage is worst near
-#' opposite boundaries, where a true risk difference of 0.966 (0.986 against
-#' 0.020) is covered 85.3% of the time and a true log risk ratio at 0.986
-#' against 0.957 is covered 92.1%. The naive comparison is a crude
-#' benchmark, and a contrast between arms at opposite boundaries is not one
-#' of the things it does well.
+#' stratified AgD or a transported [stc()] contrast. The two contrasts are
+#' worst in different places. The risk difference is worst between opposite
+#' boundaries: a true difference of 0.966 (0.986 against 0.020) is covered
+#' 85.3% of the time. The log risk ratio is worst with both arms near the
+#' same boundary, where it is the log of a ratio of two probabilities near
+#' one: 0.986 against 0.957 is covered 92.1%. The naive comparison is a
+#' crude benchmark, and neither of those configurations is one of the things
+#' it does well.
 #'
 #' Scale note: `$estimate` (and the binomial `$log_rr`) is on the link / log
 #' scale, where the null is 0. To compare against the natural-scale risk ratio

--- a/R/naive.R
+++ b/R/naive.R
@@ -20,12 +20,23 @@
 #' still reported, and they and the contrasts use the boundary pseudo-count
 #' `(r + 0.5) / (n + 1)` when an arm has zero or all events, or 0.5 events
 #' when a Poisson count is zero; the reported crude proportions and rates
-#' are unchanged. The contrasts' intervals are Wald intervals on the link
-#' scale around those corrected quantities. Enumerating every pair of counts
-#' at 100 per arm, their coverage of the true log odds ratio, log risk ratio
-#' and risk difference ranges from 0.939 to 0.9999 over true probabilities
-#' from 0.014 to 0.986, with the risk difference lowest at 0.939 beside a
-#' boundary; they are approximate, not exact.
+#' are unchanged. The link-scale contrast and the log risk ratio get Wald
+#' intervals around those corrected quantities; the risk difference gets one
+#' on the natural scale, centered on the raw difference of proportions with
+#' the corrected standard errors. All three are approximate, and their
+#' coverage is not bounded by the nominal level.
+#'
+#' Twelve configurations are pinned in the package's tests, each by
+#' enumerating every pair of counts at 100 observations per arm at a nominal
+#' 95%. Their recorded coverage runs from 0.853 to 0.9999. Those are the
+#' values at those true probabilities and they bound nothing else: the
+#' twelve do not cover other probabilities, other sample sizes, other links,
+#' stratified AgD or a transported [stc()] contrast. Coverage is worst near
+#' opposite boundaries, where a true risk difference of 0.966 (0.986 against
+#' 0.020) is covered 85.3% of the time and a true log risk ratio at 0.986
+#' against 0.957 is covered 92.1%. The naive comparison is a crude
+#' benchmark, and a contrast between arms at opposite boundaries is not one
+#' of the things it does well.
 #'
 #' Scale note: `$estimate` (and the binomial `$log_rr`) is on the link / log
 #' scale, where the null is 0. To compare against the natural-scale risk ratio

--- a/R/stc.R
+++ b/R/stc.R
@@ -128,10 +128,21 @@
 #' response surface standardized to the comparator covariate distribution,
 #' contrasted with the comparator outcome as it was observed. That
 #' difference is what `$rd` reports for a binomial outcome and `$md` for a
-#' normal one; it is not `$estimate`, which is the link-scale contrast of
-#' the same two standardized quantities, a marginal log odds ratio under a
-#' binomial logit, a log rate ratio under Poisson and a log mean ratio under
-#' a log link, as the scale note above says. No comparator response model is
+#' normal one. Whether it is also `$estimate` depends on the link. Under the
+#' normal identity link it is: `$estimate` is that same mean difference.
+#' Under a nonlinear link it is not, and `$estimate` is instead the
+#' link-scale contrast of the two standardized quantities, a marginal log
+#' odds ratio under a binomial logit, a log rate ratio under Poisson and a
+#' log mean ratio under a log link, as the scale note above says.
+#'
+#' The paragraph above is about the GLM families. Survival STC reaches its
+#' estimand by a different route: the comparator side is summarized by an
+#' intercept-only [flexsurv::flexsurvreg()] fit to the reconstructed
+#' pseudo-IPD, and its fitted RMST is contrasted with the index RMST
+#' standardized to the comparator covariates. A comparator model is
+#' therefore fitted there, although it carries no covariates and so nothing
+#' is transported into it, which is why `beta_A = beta_B` is not among the
+#' assumptions on that path either. No comparator response model is
 #' fitted and none is transported, so `beta_A = beta_B` is not among the
 #' assumptions and effect modification by itself is not a reason to set STC
 #' aside. With a binary covariate at comparator prevalence 0.75 and index

--- a/R/stc.R
+++ b/R/stc.R
@@ -18,7 +18,10 @@
 #' transformed effect measures use the boundary-only pseudo-count
 #' `(r + 0.5) / (n + 1)`; model predictions are never corrected. For Poisson
 #' outcomes, the comparator log rate uses a 0.5 continuity correction when the
-#' observed event count is zero.
+#' observed event count is zero, and `$rd` is a RATE difference on the
+#' per-unit-exposure scale, the standardized index rate minus the observed
+#' comparator rate, rather than the risk difference the binomial `$rd` is.
+#' `$estimate` stays the log rate ratio.
 #'
 #' Scale note: `$estimate` (and the binomial `$log_rr`) is on the link / log
 #' scale, where the null is 0. To compare against the natural-scale risk ratio

--- a/R/stc.R
+++ b/R/stc.R
@@ -123,10 +123,15 @@
 #' model and its applicability to the comparator population. It does not model
 #' posterior uncertainty in population covariate distributions.
 #'
-#' It does not require the two treatments to share covariate effects. The
-#' estimand is `E_B[m_A(X)] - E_B[Y_B]`: the index response surface
-#' standardized to the comparator covariate distribution, contrasted with the
-#' comparator outcome as it was observed. No comparator response model is
+#' It does not require the two treatments to share covariate effects. On the
+#' response scale the estimand is `E_B[m_A(X)] - E_B[Y_B]`: the index
+#' response surface standardized to the comparator covariate distribution,
+#' contrasted with the comparator outcome as it was observed. That
+#' difference is what `$rd` reports for a binomial outcome and `$md` for a
+#' normal one; it is not `$estimate`, which is the link-scale contrast of
+#' the same two standardized quantities, a marginal log odds ratio under a
+#' binomial logit, a log rate ratio under Poisson and a log mean ratio under
+#' a log link, as the scale note above says. No comparator response model is
 #' fitted and none is transported, so `beta_A = beta_B` is not among the
 #' assumptions and effect modification by itself is not a reason to set STC
 #' aside. With a binary covariate at comparator prevalence 0.75 and index

--- a/R/stc.R
+++ b/R/stc.R
@@ -83,9 +83,9 @@
 #'   outcome model has a boundary of its own kind: with no events, or with a
 #'   subgroup without events that a direction of the coefficients can send
 #'   to a rate of zero while every other row's rate stays fixed, the
-#'   likelihood rises without bound and the maximum likelihood estimate is
-#'   not finite, although the fitting reports convergence with finite
-#'   numbers. Such a fit is refused, as is one where the question could not
+#'   likelihood increases toward a supremum it never attains and the
+#'   maximum likelihood estimate is not finite, although the fitting
+#'   reports convergence with finite numbers. Such a fit is refused, as is one where the question could not
 #'   be decided, so a returned Poisson result has a finite maximum and its
 #'   `reason` says so. A separated fit is refused rather than returned, so
 #'   `"separated"` never appears here.
@@ -121,11 +121,30 @@
 #'
 #' The estimator relies on correct specification of the index-treatment outcome
 #' model and its applicability to the comparator population. It does not model
-#' posterior uncertainty in population covariate distributions or relax
-#' treatment-specific covariate effects.
-#' When clinically meaningful effect modification is plausible, prefer
-#' `mlumr(..., model = "relaxed")` as the primary analysis and use STC as a
-#' sensitivity or benchmarking analysis.
+#' posterior uncertainty in population covariate distributions.
+#'
+#' It does not require the two treatments to share covariate effects. The
+#' estimand is `E_B[m_A(X)] - E_B[Y_B]`: the index response surface
+#' standardized to the comparator covariate distribution, contrasted with the
+#' comparator outcome as it was observed. No comparator response model is
+#' fitted and none is transported, so `beta_A = beta_B` is not among the
+#' assumptions and effect modification by itself is not a reason to set STC
+#' aside. With a binary covariate at comparator prevalence 0.75 and index
+#' risks 0.2 and 0.8 against comparator risks 0.4 and 0.5, the slopes differ
+#' on both the risk and logit scales and the comparator-population risk
+#' difference is still 0.65 - 0.475 = 0.175. What the estimand does need is
+#' an index outcome model that is correctly specified and applicable across
+#' the comparator covariate distribution, adequate overlap, and the
+#' unanchored no-unmeasured-confounding assumption; those, not shared slopes,
+#' are where comparator-target STC is weak.
+#'
+#' Choose between this and `mlumr(..., model = "relaxed")` by the target,
+#' the evidence and the identification, not by the plausibility of effect
+#' modification. Relaxed ML-UMR is what estimates comparator-specific
+#' covariate effects, and so is what an index or other decision population, a
+#' conditional effect, or a joint model of both arms requires. `stc()`
+#' answers one question, in the comparator population, and answers it without
+#' needing those coefficients to be identified at all.
 #'
 #' The returned effect is defined in the comparator population. Applying that
 #' same effect to the index or another decision population is a separate
@@ -299,8 +318,12 @@ stc <- function(data, link = NULL, conf_level = 0.95, distribution = "weibull",
 #' constant. Along a direction `d` of the coefficients that leaves every
 #' positive-count row's predictor fixed, `X_i d = 0`, and raises none of
 #' the zero-count rows', `X_i d <= 0` with some strictly below, the linear
-#' term is constant and the exponential terms fall, so the likelihood rises
-#' all the way out and has no maximum to reach. Iterative reweighting stops
+#' term is constant and the exponential terms fall, so the likelihood
+#' increases all the way out toward a supremum it never attains. The
+#' likelihood is bounded: with no events it is `exp(-sum(E_i exp(eta_i)))`,
+#' at most 1 and approaching 1 as the intercept falls. What is missing is
+#' not an upper bound but a finite coefficient that attains one. Iterative
+#' reweighting stops
 #' anyway, when the deviance stops changing: 80 zero counts on a nonconstant
 #' covariate stop after 25 iterations at an intercept near -27.3 with a
 #' standard error near 57,500, and 40 zeros beside 40 positive counts on a
@@ -331,9 +354,10 @@ stc <- function(data, link = NULL, conf_level = 0.95, distribution = "weibull",
   if (all(y == 0)) {
     stop(
       paste(
-        "The STC outcome model has no events: the Poisson likelihood rises",
-        "without bound as the log rate falls, so the maximum likelihood",
-        "estimate is not finite, and the coefficients, the interval and the",
+        "The STC outcome model has no events: the Poisson likelihood",
+        "increases toward a supremum it never attains as the log rate",
+        "falls, so the maximum likelihood estimate is not finite, and the",
+        "coefficients, the interval and the",
         "standardized rate would describe where the fitting stopped rather",
         "than the data. Use mlumr(), whose prior makes the posterior proper."
       ),
@@ -351,9 +375,10 @@ stc <- function(data, link = NULL, conf_level = 0.95, distribution = "weibull",
         "The STC outcome model has no finite maximum likelihood estimate: a",
         "direction of the coefficients leaves the rate of every row with",
         "events fixed while lowering the rate of rows without, so the",
-        "likelihood rises along it without bound, even though the fitting",
-        "reported convergence and every returned number is finite. A",
-        "subgroup with no events is the usual cause. Use mlumr(), whose",
+        "likelihood increases along it toward a supremum it never attains,",
+        "even though the fitting reported convergence and every returned",
+        "number is finite. A subgroup with no events is the usual cause.",
+        "Use mlumr(), whose",
         "prior makes the posterior proper."
       ),
       call. = FALSE
@@ -378,8 +403,9 @@ stc <- function(data, link = NULL, conf_level = 0.95, distribution = "weibull",
     status = "not_applicable",
     reason = paste("the outcome model is Poisson, so the binomial separation",
                    "test does not apply; its likelihood was checked for a",
-                   "direction along which it rises without bound and has",
-                   "none, so the maximum likelihood estimate is finite")
+                   "direction along which it increases toward a supremum it",
+                   "never attains and has none, so the maximum likelihood",
+                   "estimate is finite")
   ))
 }
 
@@ -950,7 +976,8 @@ stc <- function(data, link = NULL, conf_level = 0.95, distribution = "weibull",
     "poisson STC rate variance"
   )
   # A fit with no events, or with a direction along which the likelihood
-  # rises without bound, never reaches here: .stc_refuse_poisson_recession()
+  # climbs to an unattained supremum, never reaches here:
+  # .stc_refuse_poisson_recession()
   # refused it, so the delta-method variance is that of an interior maximum.
   # Rate difference on the natural per-unit-exposure scale: the standardized
   # index rate minus the observed comparator rate. The standardized rate's

--- a/R/stc.R
+++ b/R/stc.R
@@ -135,17 +135,10 @@
 #' odds ratio under a binomial logit, a log rate ratio under Poisson and a
 #' log mean ratio under a log link, as the scale note above says.
 #'
-#' The paragraph above is about the GLM families. Survival STC reaches its
-#' estimand by a different route: the comparator side is summarized by an
-#' intercept-only [flexsurv::flexsurvreg()] fit to the reconstructed
-#' pseudo-IPD, and its fitted RMST is contrasted with the index RMST
-#' standardized to the comparator covariates. A comparator model is
-#' therefore fitted there, although it carries no covariates and so nothing
-#' is transported into it, which is why `beta_A = beta_B` is not among the
-#' assumptions on that path either. No comparator response model is
-#' fitted and none is transported, so `beta_A = beta_B` is not among the
-#' assumptions and effect modification by itself is not a reason to set STC
-#' aside. With a binary covariate at comparator prevalence 0.75 and index
+#' For the GLM families no comparator response model is fitted and none is
+#' transported, so `beta_A = beta_B` is not among the assumptions and effect
+#' modification by itself is not a reason to set STC aside. With a binary
+#' covariate at comparator prevalence 0.75 and index
 #' risks 0.2 and 0.8 against comparator risks 0.4 and 0.5, the slopes differ
 #' on both the risk and logit scales and the comparator-population risk
 #' difference is still 0.65 - 0.475 = 0.175. What the estimand does need is
@@ -153,6 +146,15 @@
 #' the comparator covariate distribution, adequate overlap, and the
 #' unanchored no-unmeasured-confounding assumption; those, not shared slopes,
 #' are where comparator-target STC is weak.
+#'
+#' Survival STC reaches its estimand by a different route. The comparator
+#' side is summarized by an intercept-only [flexsurv::flexsurvreg()] fit to
+#' the reconstructed pseudo-IPD, and its fitted RMST is contrasted with the
+#' index RMST standardized to the comparator covariates. So a comparator
+#' model *is* fitted on that path. It carries no covariates, so nothing is
+#' transported into it and the conclusion above about `beta_A = beta_B`
+#' holds there too, but by a different argument: not that no comparator
+#' model exists, but that the one fitted has no slopes to share.
 #'
 #' Choose between this and `mlumr(..., model = "relaxed")` by the target,
 #' the evidence and the identification, not by the plausibility of effect

--- a/man/dot-stc_refuse_poisson_recession.Rd
+++ b/man/dot-stc_refuse_poisson_recession.Rd
@@ -19,8 +19,12 @@ The Poisson log-likelihood is \verb{sum(y_i eta_i - E_i exp(eta_i))} up to a
 constant. Along a direction \code{d} of the coefficients that leaves every
 positive-count row's predictor fixed, \verb{X_i d = 0}, and raises none of
 the zero-count rows', \verb{X_i d <= 0} with some strictly below, the linear
-term is constant and the exponential terms fall, so the likelihood rises
-all the way out and has no maximum to reach. Iterative reweighting stops
+term is constant and the exponential terms fall, so the likelihood
+increases all the way out toward a supremum it never attains. The
+likelihood is bounded: with no events it is \verb{exp(-sum(E_i exp(eta_i)))},
+at most 1 and approaching 1 as the intercept falls. What is missing is
+not an upper bound but a finite coefficient that attains one. Iterative
+reweighting stops
 anyway, when the deviance stops changing: 80 zero counts on a nonconstant
 covariate stop after 25 iterations at an intercept near -27.3 with a
 standard error near 57,500, and 40 zeros beside 40 positive counts on a

--- a/man/mlumr.Rd
+++ b/man/mlumr.Rd
@@ -344,12 +344,6 @@ each row constrains the parameters. Because the parts of a split subgroup sum
 to the whole, the estimand does not change with how the aggregate evidence
 happens to be tabulated.
 
-\strong{Weakly-identified coefficients in the relaxed model}:
-\code{beta_comparator} is identified only through AgD, so the relaxed
-model needs informative priors (or many AgD rows) to estimate
-effect modification reliably. \code{\link[=prior_sensitivity]{prior_sensitivity()}} is the
-recommended diagnostic.
-
 The model assumes that all AgD rows come from the same comparator treatment
 and that, conditional on covariates, there is no between-study heterogeneity.
 If AgD rows come from multiple studies with different designs or unmeasured
@@ -400,12 +394,21 @@ treatment-specific covariate effects \code{beta_comparator} from the comparator
 intercept (the primary relaxed-SPFA strategy of Chandler & Ishak,
 Section 2.2.1). A single aggregate outcome summary generally cannot
 separately identify all comparator coefficients and the comparator
-intercept. Its likelihood term constrains one combination of them, the
-comparator intercept plus the coefficients weighted by that row's
-covariate means on the model's scale, which under \code{center = TRUE} are the
-declared means minus the pooled center; the directions the row does not
-constrain remain prior-driven, although their marginal posteriors can
-still move through the constrained combination. For one covariate with an
+intercept. What its likelihood term constrains depends on the link. With
+an identity link it is one linear combination of them, the comparator
+intercept plus the coefficients weighted by that row's covariate means on
+the model's scale, which under \code{center = TRUE} are the declared means
+minus the pooled center; the directions the row does not constrain remain
+prior-driven, although their marginal posteriors can still move through
+the constrained combination. With a nonlinear link the constrained
+quantity is the marginalized outcome mean, probability or rate, which is
+a function of the whole assumed covariate distribution and not of its
+mean profile alone: a normal outcome under \code{link = "log"} gives the
+aggregate mean \verb{exp(mu + beta m + beta^2 v / 2)}, so two rows with the
+same mean \code{m} and different variances \code{v} constrain different things and
+their Jacobian in \verb{(mu, beta)} has full rank. Local rank there is not
+global identification and neither is precision; the three have to be
+assessed separately. For one covariate with an
 identity link, independent normal priors of variance \code{a^2} on the
 intercept and \code{b^2} on the coefficient, a centered mean \code{m} and an outcome
 SE \code{s}, the posterior variance of the coefficient is
@@ -413,11 +416,11 @@ SE \code{s}, the posterior variance of the coefficient is
 row whose mean sits at the pooled center, and smaller the further the
 row's mean sits from it. Joint, nonoverlapping subgroup summaries each add
 a likelihood term; how many directions those terms identify depends on
-their number, their covariate-distribution geometry (rows with the same
-mean profile tighten one combination and add no direction), the outcome
-precision and the model, and for a nonlinear link differences in the
-distributions beyond the mean profiles matter too. Remaining directions
-require explicit prior sensitivity analysis. (Marginal, overlapping
+their number, their covariate-distribution geometry (under an identity
+link, rows with the same mean profile tighten one combination and add no
+direction; under a nonlinear link they can differ in spread or dependence
+and constrain different combinations), the outcome precision and the
+model. Remaining directions require explicit prior sensitivity analysis. (Marginal, overlapping
 subgroups would double-count patients and understate uncertainty; supply
 jointly-defined subgroups.)
 }

--- a/man/mlumr.Rd
+++ b/man/mlumr.Rd
@@ -403,10 +403,19 @@ prior-driven, although their marginal posteriors can still move through
 the constrained combination. With a nonlinear link the constrained
 quantity is the marginalized outcome mean, probability or rate, which is
 a function of the whole assumed covariate distribution and not of its
-mean profile alone: a normal outcome under \code{link = "log"} gives the
-aggregate mean \verb{exp(mu + beta m + beta^2 v / 2)}, so two rows with the
-same mean \code{m} and different variances \code{v} constrain different things and
-their Jacobian in \verb{(mu, beta)} has full rank. Local rank there is not
+mean profile alone: a normal outcome under \code{link = "log"}, with the
+covariate normally distributed within the row, gives the aggregate mean
+\verb{g = exp(mu + beta m + beta^2 v / 2)}, so two rows with the same mean \code{m}
+and different variances \code{v} can constrain different things. Both
+qualifications are load-bearing. That expression is the covariate's
+moment generating function, so it is the covariate distribution that has
+to be normal, not the outcome family alone; a distribution with the same
+first two moments and a different shape gives a different aggregate mean.
+And the Jacobian of the two rows in \verb{(mu, beta)} has determinant
+\verb{g_1 g_2 beta (v_2 - v_1)}, so it is full rank only where the variances
+differ AND the slope is away from zero. At \code{beta = 0} the two rows
+constrain the same quantity however far apart their variances are, and
+the rank drops to one. Local rank there is not
 global identification and neither is precision; the three have to be
 assessed separately. For one covariate with an
 identity link, independent normal priors of variance \code{a^2} on the

--- a/man/naive.Rd
+++ b/man/naive.Rd
@@ -44,12 +44,23 @@ size-weighted mean of its strata. The arm standard errors are
 still reported, and they and the contrasts use the boundary pseudo-count
 \code{(r + 0.5) / (n + 1)} when an arm has zero or all events, or 0.5 events
 when a Poisson count is zero; the reported crude proportions and rates
-are unchanged. The contrasts' intervals are Wald intervals on the link
-scale around those corrected quantities. Enumerating every pair of counts
-at 100 per arm, their coverage of the true log odds ratio, log risk ratio
-and risk difference ranges from 0.939 to 0.9999 over true probabilities
-from 0.014 to 0.986, with the risk difference lowest at 0.939 beside a
-boundary; they are approximate, not exact.
+are unchanged. The link-scale contrast and the log risk ratio get Wald
+intervals around those corrected quantities; the risk difference gets one
+on the natural scale, centered on the raw difference of proportions with
+the corrected standard errors. All three are approximate, and their
+coverage is not bounded by the nominal level.
+
+Twelve configurations are pinned in the package's tests, each by
+enumerating every pair of counts at 100 observations per arm at a nominal
+95\%. Their recorded coverage runs from 0.853 to 0.9999. Those are the
+values at those true probabilities and they bound nothing else: the
+twelve do not cover other probabilities, other sample sizes, other links,
+stratified AgD or a transported \code{\link[=stc]{stc()}} contrast. Coverage is worst near
+opposite boundaries, where a true risk difference of 0.966 (0.986 against
+0.020) is covered 85.3\% of the time and a true log risk ratio at 0.986
+against 0.957 is covered 92.1\%. The naive comparison is a crude
+benchmark, and a contrast between arms at opposite boundaries is not one
+of the things it does well.
 
 Scale note: \verb{$estimate} (and the binomial \verb{$log_rr}) is on the link / log
 scale, where the null is 0. To compare against the natural-scale risk ratio

--- a/man/naive.Rd
+++ b/man/naive.Rd
@@ -55,12 +55,14 @@ enumerating every pair of counts at 100 observations per arm at a nominal
 95\%. Their recorded coverage runs from 0.853 to 0.9999. Those are the
 values at those true probabilities and they bound nothing else: the
 twelve do not cover other probabilities, other sample sizes, other links,
-stratified AgD or a transported \code{\link[=stc]{stc()}} contrast. Coverage is worst near
-opposite boundaries, where a true risk difference of 0.966 (0.986 against
-0.020) is covered 85.3\% of the time and a true log risk ratio at 0.986
-against 0.957 is covered 92.1\%. The naive comparison is a crude
-benchmark, and a contrast between arms at opposite boundaries is not one
-of the things it does well.
+stratified AgD or a transported \code{\link[=stc]{stc()}} contrast. The two contrasts are
+worst in different places. The risk difference is worst between opposite
+boundaries: a true difference of 0.966 (0.986 against 0.020) is covered
+85.3\% of the time. The log risk ratio is worst with both arms near the
+same boundary, where it is the log of a ratio of two probabilities near
+one: 0.986 against 0.957 is covered 92.1\%. The naive comparison is a
+crude benchmark, and neither of those configurations is one of the things
+it does well.
 
 Scale note: \verb{$estimate} (and the binomial \verb{$log_rr}) is on the link / log
 scale, where the null is 0. To compare against the natural-scale risk ratio

--- a/man/stc.Rd
+++ b/man/stc.Rd
@@ -72,9 +72,9 @@ binomial GLM, so this particular test has nothing to say. A Poisson
 outcome model has a boundary of its own kind: with no events, or with a
 subgroup without events that a direction of the coefficients can send
 to a rate of zero while every other row's rate stays fixed, the
-likelihood rises without bound and the maximum likelihood estimate is
-not finite, although the fitting reports convergence with finite
-numbers. Such a fit is refused, as is one where the question could not
+likelihood increases toward a supremum it never attains and the
+maximum likelihood estimate is not finite, although the fitting
+reports convergence with finite numbers. Such a fit is refused, as is one where the question could not
 be decided, so a returned Poisson result has a finite maximum and its
 \code{reason} says so. A separated fit is refused rather than returned, so
 \code{"separated"} never appears here.
@@ -144,11 +144,30 @@ reconstruction uncertainty may matter.
 
 The estimator relies on correct specification of the index-treatment outcome
 model and its applicability to the comparator population. It does not model
-posterior uncertainty in population covariate distributions or relax
-treatment-specific covariate effects.
-When clinically meaningful effect modification is plausible, prefer
-\code{mlumr(..., model = "relaxed")} as the primary analysis and use STC as a
-sensitivity or benchmarking analysis.
+posterior uncertainty in population covariate distributions.
+
+It does not require the two treatments to share covariate effects. The
+estimand is \code{E_B[m_A(X)] - E_B[Y_B]}: the index response surface
+standardized to the comparator covariate distribution, contrasted with the
+comparator outcome as it was observed. No comparator response model is
+fitted and none is transported, so \code{beta_A = beta_B} is not among the
+assumptions and effect modification by itself is not a reason to set STC
+aside. With a binary covariate at comparator prevalence 0.75 and index
+risks 0.2 and 0.8 against comparator risks 0.4 and 0.5, the slopes differ
+on both the risk and logit scales and the comparator-population risk
+difference is still 0.65 - 0.475 = 0.175. What the estimand does need is
+an index outcome model that is correctly specified and applicable across
+the comparator covariate distribution, adequate overlap, and the
+unanchored no-unmeasured-confounding assumption; those, not shared slopes,
+are where comparator-target STC is weak.
+
+Choose between this and \code{mlumr(..., model = "relaxed")} by the target,
+the evidence and the identification, not by the plausibility of effect
+modification. Relaxed ML-UMR is what estimates comparator-specific
+covariate effects, and so is what an index or other decision population, a
+conditional effect, or a joint model of both arms requires. \code{stc()}
+answers one question, in the comparator population, and answers it without
+needing those coefficients to be identified at all.
 
 The returned effect is defined in the comparator population. Applying that
 same effect to the index or another decision population is a separate

--- a/man/stc.Rd
+++ b/man/stc.Rd
@@ -99,7 +99,10 @@ contrasts. When the observed comparator arm has zero or all events,
 transformed effect measures use the boundary-only pseudo-count
 \code{(r + 0.5) / (n + 1)}; model predictions are never corrected. For Poisson
 outcomes, the comparator log rate uses a 0.5 continuity correction when the
-observed event count is zero.
+observed event count is zero, and \verb{$rd} is a RATE difference on the
+per-unit-exposure scale, the standardized index rate minus the observed
+comparator rate, rather than the risk difference the binomial \verb{$rd} is.
+\verb{$estimate} stays the log rate ratio.
 
 Scale note: \verb{$estimate} (and the binomial \verb{$log_rr}) is on the link / log
 scale, where the null is 0. To compare against the natural-scale risk ratio

--- a/man/stc.Rd
+++ b/man/stc.Rd
@@ -146,10 +146,15 @@ The estimator relies on correct specification of the index-treatment outcome
 model and its applicability to the comparator population. It does not model
 posterior uncertainty in population covariate distributions.
 
-It does not require the two treatments to share covariate effects. The
-estimand is \code{E_B[m_A(X)] - E_B[Y_B]}: the index response surface
-standardized to the comparator covariate distribution, contrasted with the
-comparator outcome as it was observed. No comparator response model is
+It does not require the two treatments to share covariate effects. On the
+response scale the estimand is \code{E_B[m_A(X)] - E_B[Y_B]}: the index
+response surface standardized to the comparator covariate distribution,
+contrasted with the comparator outcome as it was observed. That
+difference is what \verb{$rd} reports for a binomial outcome and \verb{$md} for a
+normal one; it is not \verb{$estimate}, which is the link-scale contrast of
+the same two standardized quantities, a marginal log odds ratio under a
+binomial logit, a log rate ratio under Poisson and a log mean ratio under
+a log link, as the scale note above says. No comparator response model is
 fitted and none is transported, so \code{beta_A = beta_B} is not among the
 assumptions and effect modification by itself is not a reason to set STC
 aside. With a binary covariate at comparator prevalence 0.75 and index

--- a/man/stc.Rd
+++ b/man/stc.Rd
@@ -151,10 +151,21 @@ response scale the estimand is \code{E_B[m_A(X)] - E_B[Y_B]}: the index
 response surface standardized to the comparator covariate distribution,
 contrasted with the comparator outcome as it was observed. That
 difference is what \verb{$rd} reports for a binomial outcome and \verb{$md} for a
-normal one; it is not \verb{$estimate}, which is the link-scale contrast of
-the same two standardized quantities, a marginal log odds ratio under a
-binomial logit, a log rate ratio under Poisson and a log mean ratio under
-a log link, as the scale note above says. No comparator response model is
+normal one. Whether it is also \verb{$estimate} depends on the link. Under the
+normal identity link it is: \verb{$estimate} is that same mean difference.
+Under a nonlinear link it is not, and \verb{$estimate} is instead the
+link-scale contrast of the two standardized quantities, a marginal log
+odds ratio under a binomial logit, a log rate ratio under Poisson and a
+log mean ratio under a log link, as the scale note above says.
+
+The paragraph above is about the GLM families. Survival STC reaches its
+estimand by a different route: the comparator side is summarized by an
+intercept-only \code{\link[flexsurv:flexsurvreg]{flexsurv::flexsurvreg()}} fit to the reconstructed
+pseudo-IPD, and its fitted RMST is contrasted with the index RMST
+standardized to the comparator covariates. A comparator model is
+therefore fitted there, although it carries no covariates and so nothing
+is transported into it, which is why \code{beta_A = beta_B} is not among the
+assumptions on that path either. No comparator response model is
 fitted and none is transported, so \code{beta_A = beta_B} is not among the
 assumptions and effect modification by itself is not a reason to set STC
 aside. With a binary covariate at comparator prevalence 0.75 and index

--- a/man/stc.Rd
+++ b/man/stc.Rd
@@ -158,17 +158,10 @@ link-scale contrast of the two standardized quantities, a marginal log
 odds ratio under a binomial logit, a log rate ratio under Poisson and a
 log mean ratio under a log link, as the scale note above says.
 
-The paragraph above is about the GLM families. Survival STC reaches its
-estimand by a different route: the comparator side is summarized by an
-intercept-only \code{\link[flexsurv:flexsurvreg]{flexsurv::flexsurvreg()}} fit to the reconstructed
-pseudo-IPD, and its fitted RMST is contrasted with the index RMST
-standardized to the comparator covariates. A comparator model is
-therefore fitted there, although it carries no covariates and so nothing
-is transported into it, which is why \code{beta_A = beta_B} is not among the
-assumptions on that path either. No comparator response model is
-fitted and none is transported, so \code{beta_A = beta_B} is not among the
-assumptions and effect modification by itself is not a reason to set STC
-aside. With a binary covariate at comparator prevalence 0.75 and index
+For the GLM families no comparator response model is fitted and none is
+transported, so \code{beta_A = beta_B} is not among the assumptions and effect
+modification by itself is not a reason to set STC aside. With a binary
+covariate at comparator prevalence 0.75 and index
 risks 0.2 and 0.8 against comparator risks 0.4 and 0.5, the slopes differ
 on both the risk and logit scales and the comparator-population risk
 difference is still 0.65 - 0.475 = 0.175. What the estimand does need is
@@ -176,6 +169,15 @@ an index outcome model that is correctly specified and applicable across
 the comparator covariate distribution, adequate overlap, and the
 unanchored no-unmeasured-confounding assumption; those, not shared slopes,
 are where comparator-target STC is weak.
+
+Survival STC reaches its estimand by a different route. The comparator
+side is summarized by an intercept-only \code{\link[flexsurv:flexsurvreg]{flexsurv::flexsurvreg()}} fit to
+the reconstructed pseudo-IPD, and its fitted RMST is contrasted with the
+index RMST standardized to the comparator covariates. So a comparator
+model \emph{is} fitted on that path. It carries no covariates, so nothing is
+transported into it and the conclusion above about \code{beta_A = beta_B}
+holds there too, but by a different argument: not that no comparator
+model exists, but that the one fitted has no slopes to share.
 
 Choose between this and \code{mlumr(..., model = "relaxed")} by the target,
 the evidence and the identification, not by the plausibility of effect

--- a/tests/testthat/test-arm-interval-coverage.R
+++ b/tests/testthat/test-arm-interval-coverage.R
@@ -160,11 +160,15 @@ test_that("the naive Poisson arm intervals cover at least the nominal level", {
   expect_identical(ci[3, 1], 0)
 })
 
-test_that("the naive contrast intervals are calibrated as documented", {
-  # The contrasts stay Wald on the link scale around the boundary-corrected
-  # quantities. Enumerating every pair of counts at n = 100 per arm gives
-  # coverage between 0.94 and 0.999 over these true probabilities; the
-  # values are recorded so a change in the method is a change in this test.
+test_that("the naive contrast coverage is recorded at the configurations tested", {
+  # The link-scale contrast and the log risk ratio stay Wald around the
+  # boundary-corrected quantities; the risk difference is on the natural
+  # scale, centered on the raw difference of proportions. Enumerating every
+  # pair of counts at n = 100 per arm gives the coverage below AT THESE
+  # TRUE PROBABILITIES. The values are recorded so a change in the method
+  # is a change in this test. They are not a calibration envelope: nothing
+  # here bounds coverage at a probability pair that is not in the table,
+  # and the last two rows are in it because they are bad.
   n <- 100L
   d0 <- .arm_data(1L, 1L, n)
   grid <- array(NA_real_, c(n + 1L, n + 1L, 6L))
@@ -185,10 +189,13 @@ test_that("the naive contrast intervals are calibrated as documented", {
       sum(w[grid[, , 2 * k - 1] <= truth[k] & grid[, , 2 * k] >= truth[k]])
     }, numeric(1))
   }
-  # Each row: p1, p2, then the observed coverage of the log odds ratio,
-  # the log risk ratio and the risk difference, from 0.939 to 0.9999. A
-  # method change that moves any of them by more than 0.001 in either
-  # direction fails here: wider intervals are a change too.
+  # Each row: p1, p2, then the observed coverage of the log odds ratio, the
+  # log risk ratio and the risk difference. A method change that moves any
+  # of them by more than 0.001 in either direction fails here: wider
+  # intervals are a change too. The last two rows are opposite-boundary and
+  # near-boundary configurations where the intervals are badly
+  # under-calibrated; they are pinned so that stays visible and so that a
+  # method that repairs them fails this test and has to say so.
   observed <- rbind(
     c(0.014, 0.014, 0.9999, 0.9999, 0.9930),
     c(0.020, 0.020, 0.9993, 0.9994, 0.9838),
@@ -199,7 +206,9 @@ test_that("the naive contrast intervals are calibrated as documented", {
     c(0.020, 0.500, 0.9659, 0.9595, 0.9417),
     c(0.980, 0.980, 0.9993, 0.9936, 0.9838),
     c(0.986, 0.986, 0.9999, 0.9982, 0.9930),
-    c(0.986, 0.500, 0.9639, 0.9494, 0.9494)
+    c(0.986, 0.500, 0.9639, 0.9494, 0.9494),
+    c(0.986, 0.020, 0.9833, 0.9492, 0.8531),
+    c(0.986, 0.957, 0.9843, 0.9209, 0.9301)
   )
   for (i in seq_len(nrow(observed))) {
     cov <- coverage(observed[i, 1], observed[i, 2])

--- a/tests/testthat/test-stc-poisson-finite-maximum.R
+++ b/tests/testthat/test-stc-poisson-finite-maximum.R
@@ -1,8 +1,10 @@
 # A Poisson STC whose likelihood has no finite maximum. The log-likelihood is
 # sum(y eta - E exp(eta)); along a direction of the coefficients that leaves
 # every positive-count row's rate fixed and lowers a zero-count row's, it
-# rises without bound, and iterative reweighting stops anyway when the
-# deviance stops changing. What comes back is where it stopped.
+# increases toward a supremum it never attains, so no finite coefficient
+# maximizes it. The likelihood itself is bounded: with no events it is at
+# most 1. Iterative reweighting stops anyway when the deviance stops
+# changing, and what comes back is where it stopped.
 
 make_poisson <- function(y, x, binary = FALSE, target_mean = NULL) {
   source <- data.frame(trt = "A", y = y, x = x, E = 1)
@@ -39,7 +41,8 @@ test_that("an index arm with no events is refused, not reported", {
 test_that("a subgroup with no events beside events elsewhere is refused", {
   # Zero counts at x = 0 and positive counts at x = 1: the direction
   # (b0 - t, b1 + t) leaves the x = 1 rates fixed and lowers the x = 0 ones,
-  # so the likelihood rises without bound. The target population sits at
+  # so the likelihood climbs to a supremum it never reaches. The target
+  # population sits at
   # the affected profile, and the transcribed iteration stops at a slope
   # near 21 with a standard error in the thousands.
   d <- make_poisson(c(rep(0L, 40), rep(1:4, 10)), rep(c(0, 1), each = 40),


### PR DESCRIPTION
Four public statements that were true of narrower things than they described.
No behavior changes; the refusals, intervals and estimands are all unchanged.

## 1. The naive contrast coverage was a range it does not have

`?naive` said the contrast intervals cover between 0.939 and 0.9999 "over
true probabilities from 0.014 to 0.986". What was enumerated is every pair
of counts at ten probability pairs, not that domain, and the extremes of ten
values do not bound the rest. Two configurations inside the stated range:

| p index | p comparator | quantity | coverage |
|---:|---:|---|---:|
| 0.986 | 0.020 | risk difference | 0.8531140548232030 |
| 0.986 | 0.957 | log risk ratio | 0.9208640045557 |

Both are now pinned in `test-arm-interval-coverage.R` beside the other ten,
reproduced through the public `naive()` path, and the help page reports
twelve recorded values at twelve stated configurations. It also stops
calling the risk-difference interval a link-scale interval around the
boundary-corrected quantities: it is on the natural scale, centered on the
raw difference of proportions.

The pinned bad values are deliberate. A method that repairs the boundary
contrast fails this test and has to say so in the same change.

## 2. The aggregate constraint was stated as general

`?mlumr` described one aggregate row as constraining the comparator
intercept plus the coefficients weighted by that row's covariate means, and
rows with the same mean profile as adding no new direction. Both hold under
an identity link. Under a nonlinear one the constrained quantity is the
marginalized mean, a function of the whole assumed covariate distribution: a
normal outcome under `link = "log"` gives `exp(mu + beta m + beta^2 v / 2)`,
so two rows with mean 0 and variances 0 and 1 have Jacobian determinant
`exp(1/2)` in `(mu, beta)` and supply two independent local directions.

The paragraph now separates the identity-link geometry from the nonlinear
case, and says that local rank, global identification and finite-sample
precision are three different questions. The
weakly-identified-coefficients paragraph, which the help page carried
twice, is down to one.

## 3. Effect modification is not a reason to set STC aside

`?stc` told the reader to prefer `mlumr(..., model = "relaxed")` as the
primary analysis whenever clinically meaningful effect modification is
plausible. Comparator-target STC fits no comparator response model and
transports none. Its estimand is `E_B[m_A(X)] - E_B[Y_B]`, which does not
contain `beta_A = beta_B`: with a binary covariate at comparator prevalence
0.75, index risks 0.2 and 0.8 and comparator risks 0.4 and 0.5, the slopes
differ on both the risk and logit scales and the comparator-population risk
difference is still `0.65 - 0.475 = 0.175`.

The text now names the assumptions the estimand does need (a correctly
specified index outcome model applicable across the comparator covariate
distribution, overlap, unanchored no unmeasured confounding), which is where
the method is actually weak, and says to choose between STC and relaxed
ML-UMR by the target rather than by the plausibility of effect modification.

## 4. The Poisson likelihood is bounded

The refusal said the likelihood rises without bound along the recession
direction. It does not. With no events it is `exp(-sum(E_i exp(eta_i)))`,
at most 1, and approaches 1 as the intercept falls; with positive counts the
linear term is constant along the direction and the exponential terms fall
to zero. It increases toward a finite supremum that no finite coefficient
attains, which is what makes the maximum likelihood estimate not finite, and
is a different thing from the unbounded normal density the exact-fit guard
refuses.

The refusal, the geometry it tests and its three pinned messages are
unchanged; the sentences explaining them are corrected, in the roxygen,
the three `stop()` texts, the recorded `reason` and the test comments.

Full suite: 4191 passing, 0 failures, 0 errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified exact arm intervals and approximate Wald intervals for contrasts, risk ratios, and risk differences.
  - Documented observed coverage results, limitations near probability boundaries, and standardized STC intervals.
  - Expanded guidance on identification, covariate effects, variance, local rank, and prior sensitivity.
  - Clarified STC estimands, link versus response scales, comparator modeling, and survival behavior.
  - Corrected descriptions of bounded Poisson likelihoods with unattained finite suprema.

- **Tests**
  - Expanded near-boundary coverage scenarios and recorded expected results.
  - Updated Poisson likelihood test descriptions to reflect bounded behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->