### PR TITLE
Keep the lesson deployment when the docs site redeploys

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -67,10 +67,14 @@ jobs:
           # build did not produce, which includes the entire app subtree, and
           # the navbar's "Web app" entry starts serving a 404. Publishing a
           # release triggers this deployment, so the release itself is what
-          # would have broken the link.
+          # would have broken the link. The narrated lesson is deployed the
+          # same way into `lesson/` from the lesson branch, and needs the same
+          # exclusion for the same reason.
           clean-exclude: |
             app
             app/**
+            lesson
+            lesson/**
           # The app workflow pushes the same branch. A forced push from here
           # that raced it would replace its commit; without force the action
           # fetches, rebases this deployment onto whatever is there, and

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -13,7 +13,7 @@ template:
 
 navbar:
   structure:
-    left: [intro, app, reference, articles, news]
+    left: [intro, app, lesson, reference, articles, news]
     right: [search, lightswitch, github]
   components:
     # In-browser playground (separate deploy on the webapp branch at /mlumr/app),
@@ -23,6 +23,13 @@ navbar:
       icon: fa-rocket
       href: https://choxos.github.io/mlumr/app
       aria-label: mlumr web app (in-browser playground)
+    # Narrated interactive lesson (separate deploy on the lesson branch at
+    # /mlumr/lesson).
+    lesson:
+      text: Lesson
+      icon: fa-graduation-cap
+      href: https://choxos.github.io/mlumr/lesson
+      aria-label: mlumr narrated interactive lesson
     # Articles dropdown with short outcome-type labels (the full descriptive
     # titles stay on the pages themselves and in the CRAN vignette index).
     articles:


### PR DESCRIPTION
The narrated lesson will deploy into `gh-pages/lesson` from a new app-only `lesson` branch, the same way the web app deploys into `gh-pages/app` from `webapp`.

The docs deployment uses `clean: true`, which deletes every destination path the pkgdown build did not produce. Without an exclusion, the next docs deployment after the lesson is published would delete it.

Changes:
- `.github/workflows/pkgdown.yaml`: add `lesson` and `lesson/**` to `clean-exclude`.
- `_pkgdown.yml`: add a Lesson navbar entry linking to https://choxos.github.io/mlumr/lesson, next to Web app.

No package code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a navigation link to the narrated interactive lesson at `/mlumr/lesson`.

- **Bug Fixes**
  - Updated site deployment handling to preserve the separately deployed narrated lesson alongside the web app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->