### PR TITLE
Report what a Stan run left behind without naming a cause for it

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1022,6 +1022,15 @@
   continues on the chains that finished, as a partly failing multi-chain fit
   already relied on.
 
+  What it reports is the observation and the evidence that came with it, not
+  a cause. An absent file says a chain left nothing behind; a model or data
+  failure, an initialization failure, a killed process and a file removed
+  from outside all look identical from a list of paths, so naming one of them
+  would state a cause nothing established. CmdStan's own return codes are
+  attached where the installed `cmdstanr` reports them, and an exception from
+  asking for the output paths is carried into the message rather than
+  discarded, since when that is what failed it is the only account there is.
+
 ## Transportability to arbitrary target populations
 
 * **`newdata` argument** on `marginal_effects()` and `predict.mlumr_fit()`

--- a/R/backend_cmdstanr.R
+++ b/R/backend_cmdstanr.R
@@ -13,11 +13,27 @@
 #' which is the behavior a partly failing multi-chain fit already relies on.
 #' Only files that are claimed and absent, or no files at all, are refused.
 #'
+#' What this reports is the OBSERVATION and whatever evidence came with it.
+#' An absent file says a chain left nothing behind; it does not say why, and
+#' a model or data failure, an initialization failure, a killed process and
+#' an external deletion all look identical from a list of paths. Naming one
+#' of them, as this used to by calling it a failure of the run rather than
+#' of the model, states a cause nothing here established. CmdStan's own
+#' return codes and captured output are the evidence that does bear on it,
+#' so they are attached where they are available.
+#'
 #' @param files The output paths the fit reports as readable.
 #' @param chains The number of chains requested.
+#' @param retrieval_error The message from asking the fit for its output
+#'   paths, when that itself failed, or `NULL`. Discarding it, as this used
+#'   to, threw away the only account of the failure before reporting a
+#'   generic one.
+#' @param return_codes CmdStan's per-chain return codes, or `NULL` when the
+#'   installed `cmdstanr` does not report them.
 #' @return `TRUE` invisibly. Stops when there is nothing to read.
 #' @keywords internal
-.assert_cmdstan_output <- function(files, chains) {
+.assert_cmdstan_output <- function(files, chains, retrieval_error = NULL,
+                                   return_codes = NULL) {
   files <- as.character(files)
   absent <- files[!file.exists(files)]
   if (!length(absent) && length(files)) return(invisible(TRUE))
@@ -28,14 +44,30 @@
   } else {
     sprintf("none of the %d chain(s) produced output", chains)
   }
-  msg <- paste0(
-    "The Stan run left no draws to read: %s. This is a failure of the ",
-    "sampler run rather than of the model: a chain whose process never ",
-    "started, or that exited before writing its CSV, leaves nothing behind. ",
-    "Re-run with `verbose = TRUE` to see CmdStan's own messages, and set ",
-    "`output_dir` to keep them."
-  )
-  stop(sprintf(msg, detail), call. = FALSE)
+  evidence <- character(0)
+  if (length(retrieval_error) && nzchar(retrieval_error[1L])) {
+    evidence <- c(evidence, paste0("asking cmdstanr for the output paths ",
+                                   "failed with: ", retrieval_error[1L]))
+  }
+  codes <- suppressWarnings(as.integer(return_codes))
+  codes <- codes[!is.na(codes)]
+  if (length(codes)) {
+    evidence <- c(evidence, paste0("CmdStan return code(s) ",
+                                   paste(codes, collapse = ", ")))
+  }
+  evidence <- if (length(evidence)) {
+    paste0(" What is known about it: ", paste(evidence, collapse = "; "), ".")
+  } else {
+    " Nothing further was reported about it."
+  }
+  stop(sprintf(paste0(
+    "The Stan run left no draws to read: %s.%s The cause is not determined ",
+    "here: a chain whose process never started, one that exited before ",
+    "writing its CSV, a model or data failure, and a file removed from ",
+    "outside all look the same from the output paths alone. Re-run with ",
+    "`verbose = TRUE` to see CmdStan's own messages, and set `output_dir` ",
+    "to keep them."
+  ), detail, evidence), call. = FALSE)
 }
 
 #' Fit a Stan model using cmdstanr
@@ -102,9 +134,22 @@ fit_cmdstanr <- function(model_name, stan_data, chains, iter, warmup,
     dots
   )
   fit <- do.call(mod$sample, sample_args)
+  # The retrieval error is the only account of what went wrong when asking
+  # for the paths is what failed, so it is kept rather than flattened to an
+  # empty vector. `return_codes()` postdates some `cmdstanr` versions and can
+  # itself throw on a run that never started, so it is asked for defensively
+  # and the report goes out without it when it is not there.
+  retrieval <- NULL
   produced <- tryCatch(fit$output_files(include_failed = FALSE),
-                       error = function(e) character(0))
-  .assert_cmdstan_output(produced, chains)
+                       error = function(e) {
+                         retrieval <<- conditionMessage(e)
+                         character(0)
+                       })
+  .assert_cmdstan_output(
+    produced, chains,
+    retrieval_error = retrieval,
+    return_codes = tryCatch(fit$return_codes(), error = function(e) NULL)
+  )
 
   # Extract draws as plain data.frame (drop metadata columns). Keep the real
   # per-draw chain id before dropping it, so diagnostics (loo r_eff) use the

--- a/man/dot-assert_cmdstan_output.Rd
+++ b/man/dot-assert_cmdstan_output.Rd
@@ -4,12 +4,25 @@
 \alias{.assert_cmdstan_output}
 \title{Check that a CmdStan run left draws behind before reading them}
 \usage{
-.assert_cmdstan_output(files, chains)
+.assert_cmdstan_output(
+  files,
+  chains,
+  retrieval_error = NULL,
+  return_codes = NULL
+)
 }
 \arguments{
 \item{files}{The output paths the fit reports as readable.}
 
 \item{chains}{The number of chains requested.}
+
+\item{retrieval_error}{The message from asking the fit for its output
+paths, when that itself failed, or \code{NULL}. Discarding it, as this used
+to, threw away the only account of the failure before reporting a
+generic one.}
+
+\item{return_codes}{CmdStan's per-chain return codes, or \code{NULL} when the
+installed \code{cmdstanr} does not report them.}
 }
 \value{
 \code{TRUE} invisibly. Stops when there is nothing to read.
@@ -28,5 +41,14 @@ A chain that ran and failed is a different case and is not an error here:
 \code{cmdstanr} drops it and the run continues on the chains that finished,
 which is the behavior a partly failing multi-chain fit already relies on.
 Only files that are claimed and absent, or no files at all, are refused.
+
+What this reports is the OBSERVATION and whatever evidence came with it.
+An absent file says a chain left nothing behind; it does not say why, and
+a model or data failure, an initialization failure, a killed process and
+an external deletion all look identical from a list of paths. Naming one
+of them, as this used to by calling it a failure of the run rather than
+of the model, states a cause nothing here established. CmdStan's own
+return codes and captured output are the evidence that does bear on it,
+so they are attached where they are available.
 }
 \keyword{internal}

--- a/tests/testthat/test-effect-scale-and-validation.R
+++ b/tests/testthat/test-effect-scale-and-validation.R
@@ -415,8 +415,36 @@ test_that("a chain that wrote no CSV is reported, not asserted about", {
   # tempdir path to go on.
   gone <- file.path(tempdir(), "mlumr_survival_spfa-000000000000-01-000000.csv")
   expect_error(g(c(real, gone), 2L), "1 of 2 chain\\(s\\) reported output")
-  expect_error(g(c(real, gone), 2L), "sampler run rather than of the model")
   expect_error(g(gone, 1L), "not on disk")
+  # What it must NOT do is name a cause. An absent file says a chain left
+  # nothing behind; a model or data failure, an initialization failure, a
+  # killed process and an external deletion all look identical from a list
+  # of paths, and calling it a failure of the run rather than of the model
+  # asserted a distinction nothing here established.
+  expect_error(g(gone, 1L), "cause is not determined here")
+  msg <- tryCatch(g(gone, 1L), error = conditionMessage)
+  expect_false(grepl("rather than of the model", msg, fixed = TRUE))
+  expect_match(msg, "Nothing further was reported about it")
+  # The evidence that DOES bear on the cause is carried instead of dropped.
+  # Asking cmdstanr for the paths can itself fail, and that message used to
+  # be flattened to an empty vector before the generic report went out.
+  with_err <- tryCatch(
+    g(character(0), 2L, retrieval_error = "boom while listing outputs"),
+    error = conditionMessage
+  )
+  expect_match(with_err, "boom while listing outputs")
+  expect_match(with_err, "asking cmdstanr for the output paths failed")
+  with_codes <- tryCatch(g(character(0), 2L, return_codes = c(0L, 70L)),
+                         error = conditionMessage)
+  expect_match(with_codes, "CmdStan return code\\(s\\) 0, 70")
+  both <- tryCatch(g(gone, 1L, retrieval_error = "boom",
+                     return_codes = 70L), error = conditionMessage)
+  expect_match(both, "boom; CmdStan return code\\(s\\) 70")
+  # An installed cmdstanr that does not report codes leaves the message
+  # without them rather than without a message.
+  expect_match(tryCatch(g(gone, 1L, return_codes = NULL),
+                        error = conditionMessage),
+               "Nothing further was reported")
   # A chain that ran and FAILED is dropped by cmdstanr and the run continues
   # on what finished, so a shorter list of real files is not an error.
   expect_true(g(real, 2L))


### PR DESCRIPTION
`.assert_cmdstan_output()` said the failure was "of the sampler run rather than
of the model", on the evidence of a list of paths and whether they exist. An
absent file says a chain left nothing behind. It does not say why: a model or
data failure, an initialization failure, a process killed by a signal and a
file removed from outside all look identical from the paths alone, so that
sentence stated a distinction nothing had established.

It now reports the observation first, then the evidence that does bear on the
cause, then says the cause is undetermined.

* CmdStan's own return codes go into the message where the installed
  `cmdstanr` reports them. `return_codes()` postdates some versions and can
  itself throw on a run that never started, so it is asked for inside its own
  `tryCatch` and the report goes out without it when it is not there.
* An exception from `fit$output_files()` is carried into the message rather
  than flattened to `character(0)`. That flattening discarded the only account
  of the failure in exactly the case where asking for the paths is what went
  wrong.
* Where neither is available the message says "Nothing further was reported
  about it" instead of inventing an attribution.

The existence check itself, the queued-chain reasoning behind it, and the
ran-and-failed chain it deliberately tolerates are unchanged. This does not
claim to have identified the cause of the earlier missing-CSV failure; it
makes the next one report what is actually known.

## Verification

The test covers a genuinely missing claimed path, an exception while obtaining
output paths, return codes alone, both together, a `cmdstanr` that reports no
codes, and the successful extraction control. It asserts that the message does
not carry the model-versus-sampler attribution. Suite 4896 passed, 0 failed,
0 errors, 93 skipped. `lintr` clean on both touched files.
